### PR TITLE
Fix the handling of response data

### DIFF
--- a/__tests__/run.ts
+++ b/__tests__/run.ts
@@ -42,139 +42,135 @@ describe("run", () => {
       Object.defineProperty(github.context, "eventName", { value: event })
       jest.spyOn(github.context, "repo", "get").mockReturnValue({ owner: "foo", repo: "special-repo" } as any)
       octokit.graphql.mockResolvedValueOnce({
-        data: {
-          repository: {
-            pullRequests: {
-              pageInfo: {
-                hasNextPage: true,
-                endCursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyODoyNiswOTowMM4oKH4V",
-              },
-              edges: [
-                {
-                  cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyODoyNiswOTowMM4oKH4V",
-                  node: {
-                    id: "MDExOlB1bGxSZXF1ZXN0NjczNzQyMzU3",
-                    number: 13,
-                    title: "Create c.js",
-                    labels: {
-                      edges: [
-                        {
-                          node: {
-                            name: "Emergency",
+        repository: {
+          pullRequests: {
+            pageInfo: {
+              hasNextPage: true,
+              endCursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyODoyNiswOTowMM4oKH4V",
+            },
+            edges: [
+              {
+                cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyODoyNiswOTowMM4oKH4V",
+                node: {
+                  id: "MDExOlB1bGxSZXF1ZXN0NjczNzQyMzU3",
+                  number: 13,
+                  title: "Create c.js",
+                  labels: {
+                    edges: [
+                      {
+                        node: {
+                          name: "Emergency",
+                        },
+                      },
+                    ],
+                  },
+                  commits: {
+                    edges: [
+                      {
+                        node: {
+                          commit: {
+                            oid: "a7ba8efba8eff971a716ee178ae492f34c07844b",
+                            message: "Update c.js",
+                            status: null,
                           },
                         },
-                      ],
-                    },
-                    commits: {
-                      edges: [
-                        {
-                          node: {
-                            commit: {
-                              oid: "a7ba8efba8eff971a716ee178ae492f34c07844b",
-                              message: "Update c.js",
-                              status: null,
-                            },
-                          },
-                        },
-                      ],
-                    },
+                      },
+                    ],
                   },
                 },
-              ],
-            },
+              },
+            ],
           },
         },
       })
       octokit.graphql.mockResolvedValueOnce({
-        data: {
-          repository: {
-            pullRequests: {
-              pageInfo: {
-                hasNextPage: false,
-                endCursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNS0zMVQwOToyNToxOSswOTowMM4nNe7z",
-              },
-              edges: [
-                {
-                  cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyNjozMSswOTowMM4oKHtr",
-                  node: {
-                    id: "MDExOlB1bGxSZXF1ZXN0NjczNzQxNjc1",
-                    number: 12,
-                    title: "Create b.js",
-                    labels: {
-                      edges: [],
-                    },
-                    commits: {
-                      edges: [
-                        {
-                          node: {
-                            commit: {
-                              oid: "f7ef543f6bf7d321117817743d8e4f0c4fb8136f",
-                              message: "Create b.js",
-                              status: {
-                                contexts: [
-                                  {
-                                    context: "block-merge-based-on-time",
-                                    state: "SUCCESS",
-                                  },
-                                ],
-                              },
-                            },
-                          },
-                        },
-                      ],
-                    },
-                  },
-                },
-                {
-                  cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyNjowMSswOTowMM4oKHq4",
-                  node: {
-                    id: "MDExOlB1bGxSZXF1ZXN0NjczNzQxNDk2",
-                    number: 11,
-                    title: "Create a.js",
-                    labels: {
-                      edges: [],
-                    },
-                    commits: {
-                      edges: [
-                        {
-                          node: {
-                            commit: {
-                              oid: "1a097c106ca94999dee6249ba3e8c09190be9304",
-                              message: "Create a.js",
-                              status: null,
-                            },
-                          },
-                        },
-                      ],
-                    },
-                  },
-                },
-                {
-                  cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNS0zMVQwOToyNToxOSswOTowMM4nNe7z",
-                  node: {
-                    id: "MDExOlB1bGxSZXF1ZXN0NjU3ODQ2MDAz",
-                    number: 10,
-                    title: "Add empty files",
-                    labels: {
-                      edges: [],
-                    },
-                    commits: {
-                      edges: [
-                        {
-                          node: {
-                            commit: {
-                              oid: "69c87dcf047328c682ede7914d84fbcf422bcbc8",
-                              message: "fixup! Add empty files",
-                              status: null,
-                            },
-                          },
-                        },
-                      ],
-                    },
-                  },
-                },
-              ],
+        repository: {
+          pullRequests: {
+            pageInfo: {
+              hasNextPage: false,
+              endCursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNS0zMVQwOToyNToxOSswOTowMM4nNe7z",
             },
+            edges: [
+              {
+                cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyNjozMSswOTowMM4oKHtr",
+                node: {
+                  id: "MDExOlB1bGxSZXF1ZXN0NjczNzQxNjc1",
+                  number: 12,
+                  title: "Create b.js",
+                  labels: {
+                    edges: [],
+                  },
+                  commits: {
+                    edges: [
+                      {
+                        node: {
+                          commit: {
+                            oid: "f7ef543f6bf7d321117817743d8e4f0c4fb8136f",
+                            message: "Create b.js",
+                            status: {
+                              contexts: [
+                                {
+                                  context: "block-merge-based-on-time",
+                                  state: "SUCCESS",
+                                },
+                              ],
+                            },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+              {
+                cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyNjowMSswOTowMM4oKHq4",
+                node: {
+                  id: "MDExOlB1bGxSZXF1ZXN0NjczNzQxNDk2",
+                  number: 11,
+                  title: "Create a.js",
+                  labels: {
+                    edges: [],
+                  },
+                  commits: {
+                    edges: [
+                      {
+                        node: {
+                          commit: {
+                            oid: "1a097c106ca94999dee6249ba3e8c09190be9304",
+                            message: "Create a.js",
+                            status: null,
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+              {
+                cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNS0zMVQwOToyNToxOSswOTowMM4nNe7z",
+                node: {
+                  id: "MDExOlB1bGxSZXF1ZXN0NjU3ODQ2MDAz",
+                  number: 10,
+                  title: "Add empty files",
+                  labels: {
+                    edges: [],
+                  },
+                  commits: {
+                    edges: [
+                      {
+                        node: {
+                          commit: {
+                            oid: "69c87dcf047328c682ede7914d84fbcf422bcbc8",
+                            message: "fixup! Add empty files",
+                            status: null,
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
           },
         },
       })

--- a/dist/index.js
+++ b/dist/index.js
@@ -13897,6 +13897,7 @@ function handleAllPulls(inputs) {
                 let expected = state;
                 let description = state === "success" ? inputs.commitStatusDescriptionWithSuccess : inputs.commitStatusDescriptionWhileBlocking;
                 if (s.labels.includes(inputs.noBlockLabel)) {
+                    console.log('Debug', s, inputs);
                     expected = "success";
                     description = inputs.commitStatusDescriptionWithSuccess;
                 }
@@ -14006,7 +14007,6 @@ query($owner: String!, $repo: String!, $after: String) {
     }
   }
 }`, { owner, repo, after });
-            console.log("DEBUG", res);
             hasNextPage = res.repository.pullRequests.pageInfo.hasNextPage;
             after = res.repository.pullRequests.pageInfo.endCursor;
             const data = res.repository.pullRequests.edges.flatMap((pr) => pr.node.commits.edges.map((c) => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1951,7 +1951,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 var request = __nccwpck_require__(234);
 var universalUserAgent = __nccwpck_require__(429);
 
-const VERSION = "4.6.2";
+const VERSION = "4.6.4";
 
 class GraphqlError extends Error {
   constructor(request, response) {
@@ -3494,7 +3494,8 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 var deprecation = __nccwpck_require__(932);
 var once = _interopDefault(__nccwpck_require__(223));
 
-const logOnce = once(deprecation => console.warn(deprecation));
+const logOnceCode = once(deprecation => console.warn(deprecation));
+const logOnceHeaders = once(deprecation => console.warn(deprecation));
 /**
  * Error with extra properties to help with debugging
  */
@@ -3511,14 +3512,17 @@ class RequestError extends Error {
 
     this.name = "HttpError";
     this.status = statusCode;
-    Object.defineProperty(this, "code", {
-      get() {
-        logOnce(new deprecation.Deprecation("[@octokit/request-error] `error.code` is deprecated, use `error.status`."));
-        return statusCode;
-      }
+    let headers;
 
-    });
-    this.headers = options.headers || {}; // redact request credentials without mutating original request options
+    if ("headers" in options && typeof options.headers !== "undefined") {
+      headers = options.headers;
+    }
+
+    if ("response" in options) {
+      this.response = options.response;
+      headers = options.response.headers;
+    } // redact request credentials without mutating original request options
+
 
     const requestCopy = Object.assign({}, options.request);
 
@@ -3533,7 +3537,22 @@ class RequestError extends Error {
     .replace(/\bclient_secret=\w+/g, "client_secret=[REDACTED]") // OAuth tokens can be passed as URL query parameters, although it is not recommended
     // see https://developer.github.com/v3/#oauth2-token-sent-in-a-header
     .replace(/\baccess_token=\w+/g, "access_token=[REDACTED]");
-    this.request = requestCopy;
+    this.request = requestCopy; // deprecations
+
+    Object.defineProperty(this, "code", {
+      get() {
+        logOnceCode(new deprecation.Deprecation("[@octokit/request-error] `error.code` is deprecated, use `error.status`."));
+        return statusCode;
+      }
+
+    });
+    Object.defineProperty(this, "headers", {
+      get() {
+        logOnceHeaders(new deprecation.Deprecation("[@octokit/request-error] `error.headers` is deprecated, use `error.response.headers`."));
+        return headers || {};
+      }
+
+    });
   }
 
 }
@@ -3560,7 +3579,7 @@ var isPlainObject = __nccwpck_require__(287);
 var nodeFetch = _interopDefault(__nccwpck_require__(467));
 var requestError = __nccwpck_require__(537);
 
-const VERSION = "5.5.0";
+const VERSION = "5.6.0";
 
 function getBufferResponse(response) {
   return response.arrayBuffer();
@@ -3584,7 +3603,7 @@ function fetchWrapper(requestOptions) {
     redirect: requestOptions.redirect
   }, // `requestOptions.request.agent` type is incompatible
   // see https://github.com/octokit/types.ts/pull/264
-  requestOptions.request)).then(response => {
+  requestOptions.request)).then(async response => {
     url = response.url;
     status = response.status;
 
@@ -3609,49 +3628,43 @@ function fetchWrapper(requestOptions) {
       }
 
       throw new requestError.RequestError(response.statusText, status, {
-        headers,
+        response: {
+          url,
+          status,
+          headers,
+          data: undefined
+        },
         request: requestOptions
       });
     }
 
     if (status === 304) {
       throw new requestError.RequestError("Not modified", status, {
-        headers,
+        response: {
+          url,
+          status,
+          headers,
+          data: await getResponseData(response)
+        },
         request: requestOptions
       });
     }
 
     if (status >= 400) {
-      return response.text().then(message => {
-        const error = new requestError.RequestError(message, status, {
+      const data = await getResponseData(response);
+      const error = new requestError.RequestError(toErrorMessage(data), status, {
+        response: {
+          url,
+          status,
           headers,
-          request: requestOptions
-        });
-
-        try {
-          let responseBody = JSON.parse(error.message);
-          Object.assign(error, responseBody);
-          let errors = responseBody.errors; // Assumption `errors` would always be in Array format
-
-          error.message = error.message + ": " + errors.map(JSON.stringify).join(", ");
-        } catch (e) {// ignore, see octokit/rest.js#684
-        }
-
-        throw error;
+          data
+        },
+        request: requestOptions
       });
+      throw error;
     }
 
-    const contentType = response.headers.get("content-type");
-
-    if (/application\/json/.test(contentType)) {
-      return response.json();
-    }
-
-    if (!contentType || /^text\/|charset=utf-8$/.test(contentType)) {
-      return response.text();
-    }
-
-    return getBufferResponse(response);
+    return getResponseData(response);
   }).then(data => {
     return {
       status,
@@ -3660,15 +3673,40 @@ function fetchWrapper(requestOptions) {
       data
     };
   }).catch(error => {
-    if (error instanceof requestError.RequestError) {
-      throw error;
-    }
-
+    if (error instanceof requestError.RequestError) throw error;
     throw new requestError.RequestError(error.message, 500, {
-      headers,
       request: requestOptions
     });
   });
+}
+
+async function getResponseData(response) {
+  const contentType = response.headers.get("content-type");
+
+  if (/application\/json/.test(contentType)) {
+    return response.json();
+  }
+
+  if (!contentType || /^text\/|charset=utf-8$/.test(contentType)) {
+    return response.text();
+  }
+
+  return getBufferResponse(response);
+}
+
+function toErrorMessage(data) {
+  if (typeof data === "string") return data; // istanbul ignore else - just in case
+
+  if ("message" in data) {
+    if (Array.isArray(data.errors)) {
+      return `${data.message}: ${data.errors.map(JSON.stringify).join(", ")}`;
+    }
+
+    return data.message;
+  } // istanbul ignore next - just in case
+
+
+  return `Unknown error: ${JSON.stringify(data)}`;
 }
 
 function withDefaults(oldEndpoint, newDefaults) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -13897,7 +13897,6 @@ function handleAllPulls(inputs) {
                 let expected = state;
                 let description = state === "success" ? inputs.commitStatusDescriptionWithSuccess : inputs.commitStatusDescriptionWhileBlocking;
                 if (s.labels.includes(inputs.noBlockLabel)) {
-                    console.log('Debug', s, inputs);
                     expected = "success";
                     description = inputs.commitStatusDescriptionWithSuccess;
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -13968,10 +13968,10 @@ query($owner: String!, $repo: String!, $after: String) {
     }
   }
 }`, { owner, repo, after });
-            console.log('DEBUG', res);
-            hasNextPage = res.data.repository.pullRequests.pageInfo.hasNextPage;
-            after = res.data.repository.pullRequests.pageInfo.endCursor;
-            const data = res.data.repository.pullRequests.edges.flatMap((pr) => pr.node.commits.edges.map((c) => {
+            console.log("DEBUG", res);
+            hasNextPage = res.repository.pullRequests.pageInfo.hasNextPage;
+            after = res.repository.pullRequests.pageInfo.endCursor;
+            const data = res.repository.pullRequests.edges.flatMap((pr) => pr.node.commits.edges.map((c) => {
                 var _a, _b;
                 return ({
                     number: pr.node.number,

--- a/dist/index.js
+++ b/dist/index.js
@@ -13968,6 +13968,7 @@ query($owner: String!, $repo: String!, $after: String) {
     }
   }
 }`, { owner, repo, after });
+            console.log('DEBUG', res);
             hasNextPage = res.data.repository.pullRequests.pageInfo.hasNextPage;
             after = res.data.repository.pullRequests.pageInfo.endCursor;
             const data = res.data.repository.pullRequests.edges.flatMap((pr) => pr.node.commits.edges.map((c) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1061,11 +1061,11 @@
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.2.tgz",
-      "integrity": "sha512-WmsIR1OzOr/3IqfG9JIczI8gMJUMzzyx5j0XXQ4YihHtKlQc+u35VpVoOXhlKAlaBntvry1WpAzPl/a+s3n89Q==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.4.tgz",
+      "integrity": "sha512-SWTdXsVheRmlotWNjKzPOb6Js6tjSqA2a8z9+glDJng0Aqjzti8MEWOtuT8ZSu6wHnci7LZNuarE87+WJBG4vg==",
       "dependencies": {
-        "@octokit/request": "^5.3.0",
+        "@octokit/request": "^5.6.0",
         "@octokit/types": "^6.0.3",
         "universal-user-agent": "^6.0.0"
       }
@@ -1099,12 +1099,12 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.5.0.tgz",
-      "integrity": "sha512-jxbMLQdQ3heFMZUaTLSCqcKs2oAHEYh7SnLLXyxbZmlULExZ/RXai7QUWWFKowcGGPlCZuKTZg0gSKHWrfYEoQ==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.0.tgz",
+      "integrity": "sha512-4cPp/N+NqmaGQwbh3vUsYqokQIzt7VjsgTYVXiwpUP2pxd5YiZB2XuTedbb0SPtv9XS7nzAKjAuQxmY8/aZkiA==",
       "dependencies": {
         "@octokit/endpoint": "^6.0.1",
-        "@octokit/request-error": "^2.0.0",
+        "@octokit/request-error": "^2.1.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
         "node-fetch": "^2.6.1",
@@ -1112,9 +1112,9 @@
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz",
-      "integrity": "sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
       "dependencies": {
         "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
@@ -6581,11 +6581,11 @@
       }
     },
     "@octokit/graphql": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.2.tgz",
-      "integrity": "sha512-WmsIR1OzOr/3IqfG9JIczI8gMJUMzzyx5j0XXQ4YihHtKlQc+u35VpVoOXhlKAlaBntvry1WpAzPl/a+s3n89Q==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.4.tgz",
+      "integrity": "sha512-SWTdXsVheRmlotWNjKzPOb6Js6tjSqA2a8z9+glDJng0Aqjzti8MEWOtuT8ZSu6wHnci7LZNuarE87+WJBG4vg==",
       "requires": {
-        "@octokit/request": "^5.3.0",
+        "@octokit/request": "^5.6.0",
         "@octokit/types": "^6.0.3",
         "universal-user-agent": "^6.0.0"
       }
@@ -6613,12 +6613,12 @@
       }
     },
     "@octokit/request": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.5.0.tgz",
-      "integrity": "sha512-jxbMLQdQ3heFMZUaTLSCqcKs2oAHEYh7SnLLXyxbZmlULExZ/RXai7QUWWFKowcGGPlCZuKTZg0gSKHWrfYEoQ==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.0.tgz",
+      "integrity": "sha512-4cPp/N+NqmaGQwbh3vUsYqokQIzt7VjsgTYVXiwpUP2pxd5YiZB2XuTedbb0SPtv9XS7nzAKjAuQxmY8/aZkiA==",
       "requires": {
         "@octokit/endpoint": "^6.0.1",
-        "@octokit/request-error": "^2.0.0",
+        "@octokit/request-error": "^2.1.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
         "node-fetch": "^2.6.1",
@@ -6626,9 +6626,9 @@
       }
     },
     "@octokit/request-error": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz",
-      "integrity": "sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
       "requires": {
         "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",

--- a/src/run.ts
+++ b/src/run.ts
@@ -190,6 +190,7 @@ query($owner: String!, $repo: String!, $after: String) {
 }`,
       { owner, repo, after }
     )
+    console.log('DEBUG', res)
     hasNextPage = res.data.repository.pullRequests.pageInfo.hasNextPage
     after = res.data.repository.pullRequests.pageInfo.endCursor
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -92,43 +92,41 @@ async function handlePull(inputs: Inputs, payload: PullRequestEvent): Promise<vo
 }
 
 interface StatusesResponse {
-  readonly data: {
-    readonly repository: {
-      readonly pullRequests: {
-        readonly pageInfo: {
-          readonly hasNextPage: boolean
-          readonly endCursor: string | null
-        }
-        readonly edges: {
-          readonly node: {
-            readonly number: number
-            readonly title: string
-            readonly labels: {
-              readonly edges: {
-                readonly node: {
-                  readonly name: string
-                }
-              }[]
-            }
-            readonly commits: {
-              readonly edges: {
-                readonly node: {
-                  readonly commit: {
-                    readonly oid: string
-                    readonly message: string
-                    readonly status: {
-                      readonly contexts: {
-                        readonly context: string
-                        readonly state: string
-                      }[]
-                    } | null
-                  }
-                }
-              }[]
-            }
-          }
-        }[]
+  readonly repository: {
+    readonly pullRequests: {
+      readonly pageInfo: {
+        readonly hasNextPage: boolean
+        readonly endCursor: string | null
       }
+      readonly edges: {
+        readonly node: {
+          readonly number: number
+          readonly title: string
+          readonly labels: {
+            readonly edges: {
+              readonly node: {
+                readonly name: string
+              }
+            }[]
+          }
+          readonly commits: {
+            readonly edges: {
+              readonly node: {
+                readonly commit: {
+                  readonly oid: string
+                  readonly message: string
+                  readonly status: {
+                    readonly contexts: {
+                      readonly context: string
+                      readonly state: string
+                    }[]
+                  } | null
+                }
+              }
+            }[]
+          }
+        }
+      }[]
     }
   }
 }
@@ -190,11 +188,11 @@ query($owner: String!, $repo: String!, $after: String) {
 }`,
       { owner, repo, after }
     )
-    console.log('DEBUG', res)
-    hasNextPage = res.data.repository.pullRequests.pageInfo.hasNextPage
-    after = res.data.repository.pullRequests.pageInfo.endCursor
+    console.log("DEBUG", res)
+    hasNextPage = res.repository.pullRequests.pageInfo.hasNextPage
+    after = res.repository.pullRequests.pageInfo.endCursor
 
-    const data = res.data.repository.pullRequests.edges.flatMap((pr) =>
+    const data = res.repository.pullRequests.edges.flatMap((pr) =>
       pr.node.commits.edges.map((c) => ({
         number: pr.node.number,
         sha: c.node.commit.oid,

--- a/src/run.ts
+++ b/src/run.ts
@@ -28,6 +28,7 @@ async function handleAllPulls(inputs: Inputs): Promise<void> {
       let description =
         state === "success" ? inputs.commitStatusDescriptionWithSuccess : inputs.commitStatusDescriptionWhileBlocking
       if (s.labels.includes(inputs.noBlockLabel)) {
+        console.log('Debug', s, inputs)
         expected = "success"
         description = inputs.commitStatusDescriptionWithSuccess
       }
@@ -188,7 +189,6 @@ query($owner: String!, $repo: String!, $after: String) {
 }`,
       { owner, repo, after }
     )
-    console.log("DEBUG", res)
     hasNextPage = res.repository.pullRequests.pageInfo.hasNextPage
     after = res.repository.pullRequests.pageInfo.endCursor
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -28,7 +28,6 @@ async function handleAllPulls(inputs: Inputs): Promise<void> {
       let description =
         state === "success" ? inputs.commitStatusDescriptionWithSuccess : inputs.commitStatusDescriptionWhileBlocking
       if (s.labels.includes(inputs.noBlockLabel)) {
-        console.log('Debug', s, inputs)
         expected = "success"
         description = inputs.commitStatusDescriptionWithSuccess
       }


### PR DESCRIPTION
According to [`@octokit/graphql`](https://github.com/octokit/graphql.js), a succeeded response does not wrap data with the key `"data"`. It means the user of `@octokit/graphql` does not have to consider access the real field through `"data"`; for example, we should call `response.repository` instead of `response.data.repository`.

So, this PR extracted `data` access from the response.

Note it's easier to enable "Hide whitespace changes" when reading the changes of this PR.