### PR TITLE
Use --include-tags-regex to exluce shortcut tags

### DIFF
--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -12,4 +12,5 @@ github_changelog_generator \
   --user "${GITHUB_REPOSITORY%/*}" \
   --project "${GITHUB_REPOSITORY#*/}" \
   --exclude-labels chore,no-changelog,duplicate,question,invalid,wontfix \
+  --include-tags-regex 'v\d+\.\d+\.\d+' \
   "${suffix[@]}"


### PR DESCRIPTION
I want to exclude this line.

https://github.com/yykamei/block-merge-based-on-time/pull/28/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR13