### PR TITLE
Use cache for setup-node

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "12"
+          cache: npm
       - run: npm ci
       - run: npm run build
       - run: git diff --exit-code --quiet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - run: npm ci
       - run: npm run fmt:check
       - run: npm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
+          cache: npm
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3


### PR DESCRIPTION
See the details on
https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/