### PR TITLE
Do not run git-push(1) when apply is not true

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         run: ./scripts/git_push.sh
         env:
           COMMIT_MESSAGE: Bump to ${{ github.event.inputs.version }}
+        if: github.event.inputs.apply == 'true'
       - name: Create a GitHub release and publish the crate on crates.io
         run: ./scripts/release.sh
         env:


### PR DESCRIPTION
I want to test what will happen with the workflow "Release" without affecting actual data.
This patch will stop git-push(1) when `apply` is not `'true'`.