### PR TITLE
Run `npm run build` while updating holidays

### DIFF
--- a/.github/workflows/fetch-holidays.yml
+++ b/.github/workflows/fetch-holidays.yml
@@ -10,12 +10,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "12"
           cache: npm
       - run: npm ci
       - run: npm run fetch-holidays
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      - run: npm run build
       - name: git-push(1)
         run: ./scripts/git-push.sh
         env:


### PR DESCRIPTION
`fetch-holiday` should trigger `npm run build` whenever the workflow updates holiday information.
So, I added a new step `npm run build` in `fetch-holiday`.

By the way, `npm run build` should be run with the same runtime as `auto-build`, so I also changed `node-version` from `16` to `12`.