### PR TITLE
[Refactor] Use git-push.sh in auto-build

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13811,7 +13811,6 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         const inputs = new Inputs();
-        console.log('test');
         switch (github.context.eventName) {
             case "schedule":
             case "workflow_dispatch":


### PR DESCRIPTION
This workflow contained the same functionality as `git-push.sh`. The workflow can use the shell script.