### PR TITLE
Update tags at the same time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
         description: version. The next release version (without prefix v)
         required: true
       apply:
-        description: apply. Specify whether the atcual release should be performed or not
+        description: apply. Specify whether the actual release should be performed or not
         default: "false"
         required: true
 jobs:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -26,8 +26,6 @@ cat /tmp/notes.txt
 
 git tag --force "$MINOR_TAG"
 git tag --force "$MAJOR_TAG"
-git show "$MINOR_TAG"
-git show "$MAJOR_TAG"
 
 if [[ "$APPLY" == "true" ]]; then
   gh release create "$FUTURE_RELEASE" --title "$RELEASE_TITLE" --notes-file /tmp/notes.txt

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,6 +6,9 @@ set -xeuo pipefail
 grep -F "## [${FUTURE_RELEASE}]" CHANGELOG.md
 grep -F '## [Unreleased]' CHANGELOG.md && exit 1
 
+MINOR_TAG="${FUTURE_RELEASE%.*}"
+MAJOR_TAG="${FUTURE_RELEASE%%.*}"
+
 # Extract the latest changelog entries to put them into GitHub release notes.
 hit=0
 while IFS="" read -r line; do
@@ -21,6 +24,12 @@ done < CHANGELOG.md
 gh release list
 cat /tmp/notes.txt
 
+git tag --force "$MINOR_TAG"
+git tag --force "$MAJOR_TAG"
+git show "$MINOR_TAG"
+git show "$MAJOR_TAG"
+
 if [[ "$APPLY" == "true" ]]; then
   gh release create "$FUTURE_RELEASE" --title "$RELEASE_TITLE" --notes-file /tmp/notes.txt
+  git push --force --tags
 fi


### PR DESCRIPTION
GitHub Action should provide major or major and minor only tags for convenience.
This patch tries to push such tags while releasing them at the same time.