### PR TITLE
Add a new parameter `base-branches`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ jobs:
         with:
           after: "17:30, 16:30 on Monday"
           before: 09:00
+          base-branches: "(default)"
           timezone: Pacific/Honolulu
           prohibited-days-dates: "Sunday, 2021-10-01, 2021-12-29/2022-01-04, H:United States, BH:United States"
 ```
@@ -47,6 +48,7 @@ These are all available inputs.
 | `after`                                    | The time to start blocking merge. You can set exception time for specific days. For example, the value could be "17:30, 16:30 on Monday"                                                                                                                                                                                                                                                                                                                                                                                                                                  | `true`   | -                                                                                  |
 | `before`                                   | The time to stop blocking merge. You can set exception time for specific days. For example, the value could be "09:00, 08:00 on Monday"                                                                                                                                                                                                                                                                                                                                                                                                                                   | `true`   | -                                                                                  |
 | `timezone`                                 | Time zone to use. Default is UTC                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | `true`   | -                                                                                  |
+| `base-branches`                            | The comma-separated base branches of pull requests. This tool will block only pull requests the base branches of which are listed in this parameter. You can set regular expressions surrounding with `/` like `/staging\/.*/` and just set string literals like `develop`. Also, the value `(default)` is acceptable, which means pull requests that will be merged into the default branch will be blocked. The default value is `/^.*$/` for backward compatibility.                                                                                                   | `false`  | `"/^.*$/"`                                                                         |
 | `prohibited-days-dates`                    | The comma-separated days or dates to stop blocking merge for all day. You can also specify regional holidays with special syntax, such as "H:St. Barthélemy" and "BH:St. Barthélemy", which stand for "holidays of St. Barthélemy" and "before holidays of St. Barthélemy." The word after "H:" or "BH:" is a region name that is listed in [`src/holidays.json`](https://raw.githubusercontent.com/yykamei/block-merge-based-on-time/main/src/holidays.json) as a JSON key. For example, the value could be "Sunday, 2021-08-01, 2021-08-06/2021-08-10, H:Côte d’Ivoire" | `false`  | `""`                                                                               |
 | `no-block-label`                           | The label to indicate the pull request should not be blocked                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | `false`  | `no-block`                                                                         |
 | `commit-status-context`                    | The commit status context                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | `false`  | `block-merge-based-on-time`                                                        |
@@ -57,10 +59,14 @@ These are all available inputs.
 
 ## Regional holidays
 
-This tool supports blocking merges based on regional holidays. For example, February 11th is "National Foundation Day" in Japan, and you can block merges on such a holiday via `prohibited-days-dates` with `H:Japan`. In addition, you can also block on the day before the regional holiday with `BH:Japan`.
+This tool supports blocking merges based on regional holidays. For example, February 11th is "National Foundation Day"
+in Japan, and you can block merges on such a holiday via `prohibited-days-dates` with `H:Japan`. In addition, you can
+also block on the day before the regional holiday with `BH:Japan`.
 
-Block Merge Based on Time supports **232** regions, taking advantage of Google Calendar API, and the data is updated periodically.
-See [`src/holidays.json`](https://raw.githubusercontent.com/yykamei/block-merge-based-on-time/main/src/holidays.json) to check all available regions.
+Block Merge Based on Time supports **232** regions, taking advantage of Google Calendar API, and the data is updated
+periodically.
+See [`src/holidays.json`](https://raw.githubusercontent.com/yykamei/block-merge-based-on-time/main/src/holidays.json) to
+check all available regions.
 
 ## Contributing
 

--- a/__tests__/run.ts
+++ b/__tests__/run.ts
@@ -12,10 +12,11 @@ describe("run", () => {
       },
     },
   }
+  let getInput: any
 
   beforeAll(() => {
     jest.useFakeTimers()
-    jest.spyOn(core, "getInput").mockImplementation(
+    getInput = jest.spyOn(core, "getInput").mockImplementation(
       (name) =>
         ({
           token: "abc",
@@ -28,6 +29,7 @@ describe("run", () => {
           "commit-status-description-with-success": "",
           "commit-status-description-while-blocking": "",
           "commit-status-url": "",
+          "base-branches": "/^.*$/",
         }[name] as any)
     )
     jest.spyOn(github, "getOctokit").mockImplementation(() => octokit as any)
@@ -38,240 +40,558 @@ describe("run", () => {
   })
 
   describe.each([["schedule"], ["workflow_dispatch"]])("when the event is %s", (event) => {
-    beforeEach(() => {
-      Object.defineProperty(github.context, "eventName", { value: event })
-      jest.spyOn(github.context, "repo", "get").mockReturnValue({ owner: "foo", repo: "special-repo" } as any)
-      octokit.graphql.mockResolvedValueOnce({
-        repository: {
-          pullRequests: {
-            pageInfo: {
-              hasNextPage: true,
-              endCursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyODoyNiswOTowMM4oKH4V",
+    describe("when base-branches is the default value", () => {
+      beforeEach(() => {
+        Object.defineProperty(github.context, "eventName", { value: event })
+        jest.spyOn(github.context, "repo", "get").mockReturnValue({ owner: "foo", repo: "special-repo" } as any)
+        octokit.graphql.mockResolvedValueOnce({
+          repository: {
+            defaultBranchRef: {
+              name: "main",
             },
-            edges: [
-              {
-                cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyODoyNiswOTowMM4oKH4V",
-                node: {
-                  id: "MDExOlB1bGxSZXF1ZXN0NjczNzQyMzU3",
-                  number: 13,
-                  title: "Create c.js",
-                  labels: {
-                    edges: [
-                      {
-                        node: {
-                          name: "Emergency",
-                        },
-                      },
-                    ],
-                  },
-                  commits: {
-                    edges: [
-                      {
-                        node: {
-                          commit: {
-                            oid: "a7ba8efba8eff971a716ee178ae492f34c07844b",
-                            message: "Update c.js",
-                            status: null,
+          },
+        })
+        octokit.graphql.mockResolvedValueOnce({
+          repository: {
+            pullRequests: {
+              pageInfo: {
+                hasNextPage: true,
+                endCursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyODoyNiswOTowMM4oKH4V",
+              },
+              edges: [
+                {
+                  cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyODoyNiswOTowMM4oKH4V",
+                  node: {
+                    id: "MDExOlB1bGxSZXF1ZXN0NjczNzQyMzU3",
+                    number: 13,
+                    title: "Create c.js",
+                    baseRef: {
+                      name: "main",
+                    },
+                    labels: {
+                      edges: [
+                        {
+                          node: {
+                            name: "Emergency",
                           },
                         },
-                      },
-                    ],
-                  },
-                },
-              },
-            ],
-          },
-        },
-      })
-      octokit.graphql.mockResolvedValueOnce({
-        repository: {
-          pullRequests: {
-            pageInfo: {
-              hasNextPage: false,
-              endCursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNS0zMVQwOToyNToxOSswOTowMM4nNe7z",
-            },
-            edges: [
-              {
-                cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyNjozMSswOTowMM4oKHtr",
-                node: {
-                  id: "MDExOlB1bGxSZXF1ZXN0NjczNzQxNjc1",
-                  number: 12,
-                  title: "Create b.js",
-                  labels: {
-                    edges: [],
-                  },
-                  commits: {
-                    edges: [
-                      {
-                        node: {
-                          commit: {
-                            oid: "f7ef543f6bf7d321117817743d8e4f0c4fb8136f",
-                            message: "Create b.js",
-                            status: {
-                              contexts: [
-                                {
-                                  context: "block-merge-based-on-time",
-                                  state: "SUCCESS",
-                                },
-                              ],
+                      ],
+                    },
+                    commits: {
+                      edges: [
+                        {
+                          node: {
+                            commit: {
+                              oid: "a7ba8efba8eff971a716ee178ae492f34c07844b",
+                              message: "Update c.js",
+                              status: null,
                             },
                           },
                         },
-                      },
-                    ],
+                      ],
+                    },
                   },
                 },
-              },
-              {
-                cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyNjowMSswOTowMM4oKHq4",
-                node: {
-                  id: "MDExOlB1bGxSZXF1ZXN0NjczNzQxNDk2",
-                  number: 11,
-                  title: "Create a.js",
-                  labels: {
-                    edges: [],
-                  },
-                  commits: {
-                    edges: [
-                      {
-                        node: {
-                          commit: {
-                            oid: "1a097c106ca94999dee6249ba3e8c09190be9304",
-                            message: "Create a.js",
-                            status: null,
-                          },
-                        },
-                      },
-                    ],
-                  },
-                },
-              },
-              {
-                cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNS0zMVQwOToyNToxOSswOTowMM4nNe7z",
-                node: {
-                  id: "MDExOlB1bGxSZXF1ZXN0NjU3ODQ2MDAz",
-                  number: 10,
-                  title: "Add empty files",
-                  labels: {
-                    edges: [],
-                  },
-                  commits: {
-                    edges: [
-                      {
-                        node: {
-                          commit: {
-                            oid: "69c87dcf047328c682ede7914d84fbcf422bcbc8",
-                            message: "fixup! Add empty files",
-                            status: null,
-                          },
-                        },
-                      },
-                    ],
-                  },
-                },
-              },
-            ],
+              ],
+            },
           },
-        },
-      })
-    })
-
-    test("makes all pull requests pending, aside from ones with labels", async () => {
-      jest.setSystemTime(new Date("2021-06-17T13:30:00-10:00"))
-      await run()
-      expect(octokit.graphql).toHaveBeenNthCalledWith(1, expect.any(String), {
-        owner: "foo",
-        repo: "special-repo",
-        after: null,
-      })
-      expect(octokit.graphql).toHaveBeenNthCalledWith(2, expect.any(String), {
-        owner: "foo",
-        repo: "special-repo",
-        after: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyODoyNiswOTowMM4oKH4V",
-      })
-      expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(1, {
-        owner: "foo",
-        repo: "special-repo",
-        sha: "a7ba8efba8eff971a716ee178ae492f34c07844b",
-        state: "success",
-        context: "block-merge-based-on-time",
-        description: "The PR could be merged",
-        target_url: undefined,
-      })
-      expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(2, {
-        owner: "foo",
-        repo: "special-repo",
-        sha: "f7ef543f6bf7d321117817743d8e4f0c4fb8136f",
-        state: "pending",
-        context: "block-merge-based-on-time",
-        description: "The PR can't be merged based on time, which is due to your organization's policy",
-        target_url: undefined,
-      })
-      expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(3, {
-        owner: "foo",
-        repo: "special-repo",
-        sha: "1a097c106ca94999dee6249ba3e8c09190be9304",
-        state: "pending",
-        context: "block-merge-based-on-time",
-        description: "The PR can't be merged based on time, which is due to your organization's policy",
-        target_url: undefined,
-      })
-      expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(4, {
-        owner: "foo",
-        repo: "special-repo",
-        sha: "69c87dcf047328c682ede7914d84fbcf422bcbc8",
-        state: "pending",
-        context: "block-merge-based-on-time",
-        description: "The PR can't be merged based on time, which is due to your organization's policy",
-        target_url: undefined,
-      })
-    })
-
-    test("makes all pull requests success but don't create status if it's already success", async () => {
-      jest.setSystemTime(new Date("2021-06-17T11:30:00-10:00"))
-      await run()
-      expect(octokit.graphql).toHaveBeenNthCalledWith(1, expect.any(String), {
-        owner: "foo",
-        repo: "special-repo",
-        after: null,
-      })
-      expect(octokit.graphql).toHaveBeenNthCalledWith(2, expect.any(String), {
-        owner: "foo",
-        repo: "special-repo",
-        after: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyODoyNiswOTowMM4oKH4V",
-      })
-      expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(1, {
-        owner: "foo",
-        repo: "special-repo",
-        sha: "a7ba8efba8eff971a716ee178ae492f34c07844b",
-        state: "success",
-        context: "block-merge-based-on-time",
-        description: "The PR could be merged",
-        target_url: undefined,
-      })
-      expect(octokit.rest.repos.createCommitStatus).not.toHaveBeenCalledWith(
-        // It's already been success
-        expect.objectContaining({
-          sha: "f7ef543f6bf7d321117817743d8e4f0c4fb8136f",
         })
-      )
-      expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(2, {
-        owner: "foo",
-        repo: "special-repo",
-        sha: "1a097c106ca94999dee6249ba3e8c09190be9304",
-        state: "success",
-        context: "block-merge-based-on-time",
-        description: "The PR could be merged",
-        target_url: undefined,
+        octokit.graphql.mockResolvedValueOnce({
+          repository: {
+            pullRequests: {
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNS0zMVQwOToyNToxOSswOTowMM4nNe7z",
+              },
+              edges: [
+                {
+                  cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyNjozMSswOTowMM4oKHtr",
+                  node: {
+                    id: "MDExOlB1bGxSZXF1ZXN0NjczNzQxNjc1",
+                    number: 12,
+                    title: "Create b.js",
+                    baseRef: {
+                      name: "main",
+                    },
+                    labels: {
+                      edges: [],
+                    },
+                    commits: {
+                      edges: [
+                        {
+                          node: {
+                            commit: {
+                              oid: "f7ef543f6bf7d321117817743d8e4f0c4fb8136f",
+                              message: "Create b.js",
+                              status: {
+                                contexts: [
+                                  {
+                                    context: "block-merge-based-on-time",
+                                    state: "SUCCESS",
+                                  },
+                                ],
+                              },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyNjowMSswOTowMM4oKHq4",
+                  node: {
+                    id: "MDExOlB1bGxSZXF1ZXN0NjczNzQxNDk2",
+                    number: 11,
+                    title: "Create a.js",
+                    baseRef: {
+                      name: "main",
+                    },
+                    labels: {
+                      edges: [],
+                    },
+                    commits: {
+                      edges: [
+                        {
+                          node: {
+                            commit: {
+                              oid: "1a097c106ca94999dee6249ba3e8c09190be9304",
+                              message: "Create a.js",
+                              status: null,
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNS0zMVQwOToyNToxOSswOTowMM4nNe7z",
+                  node: {
+                    id: "MDExOlB1bGxSZXF1ZXN0NjU3ODQ2MDAz",
+                    number: 10,
+                    title: "Add empty files",
+                    baseRef: {
+                      name: "develop",
+                    },
+                    labels: {
+                      edges: [],
+                    },
+                    commits: {
+                      edges: [
+                        {
+                          node: {
+                            commit: {
+                              oid: "69c87dcf047328c682ede7914d84fbcf422bcbc8",
+                              message: "fixup! Add empty files",
+                              status: null,
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        })
       })
-      expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(3, {
-        owner: "foo",
-        repo: "special-repo",
-        sha: "69c87dcf047328c682ede7914d84fbcf422bcbc8",
-        state: "success",
-        context: "block-merge-based-on-time",
-        description: "The PR could be merged",
-        target_url: undefined,
+      test("makes all pull requests pending, aside from ones with labels", async () => {
+        jest.setSystemTime(new Date("2021-06-17T13:30:00-10:00"))
+        await run()
+        expect(octokit.graphql).toHaveBeenNthCalledWith(1, expect.any(String), {
+          owner: "foo",
+          repo: "special-repo",
+        })
+        expect(octokit.graphql).toHaveBeenNthCalledWith(2, expect.any(String), {
+          owner: "foo",
+          repo: "special-repo",
+          after: null,
+        })
+        expect(octokit.graphql).toHaveBeenNthCalledWith(3, expect.any(String), {
+          owner: "foo",
+          repo: "special-repo",
+          after: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyODoyNiswOTowMM4oKH4V",
+        })
+        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(1, {
+          owner: "foo",
+          repo: "special-repo",
+          sha: "a7ba8efba8eff971a716ee178ae492f34c07844b",
+          state: "success",
+          context: "block-merge-based-on-time",
+          description: "The PR could be merged",
+          target_url: undefined,
+        })
+        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(2, {
+          owner: "foo",
+          repo: "special-repo",
+          sha: "f7ef543f6bf7d321117817743d8e4f0c4fb8136f",
+          state: "pending",
+          context: "block-merge-based-on-time",
+          description: "The PR can't be merged based on time, which is due to your organization's policy",
+          target_url: undefined,
+        })
+        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(3, {
+          owner: "foo",
+          repo: "special-repo",
+          sha: "1a097c106ca94999dee6249ba3e8c09190be9304",
+          state: "pending",
+          context: "block-merge-based-on-time",
+          description: "The PR can't be merged based on time, which is due to your organization's policy",
+          target_url: undefined,
+        })
+        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(4, {
+          owner: "foo",
+          repo: "special-repo",
+          sha: "69c87dcf047328c682ede7914d84fbcf422bcbc8",
+          state: "pending",
+          context: "block-merge-based-on-time",
+          description: "The PR can't be merged based on time, which is due to your organization's policy",
+          target_url: undefined,
+        })
+      })
+      test("makes all pull requests success but don't create status if it's already success", async () => {
+        jest.setSystemTime(new Date("2021-06-17T11:30:00-10:00"))
+        await run()
+        expect(octokit.graphql).toHaveBeenNthCalledWith(1, expect.any(String), {
+          owner: "foo",
+          repo: "special-repo",
+        })
+        expect(octokit.graphql).toHaveBeenNthCalledWith(2, expect.any(String), {
+          owner: "foo",
+          repo: "special-repo",
+          after: null,
+        })
+        expect(octokit.graphql).toHaveBeenNthCalledWith(3, expect.any(String), {
+          owner: "foo",
+          repo: "special-repo",
+          after: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyODoyNiswOTowMM4oKH4V",
+        })
+        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(1, {
+          owner: "foo",
+          repo: "special-repo",
+          sha: "a7ba8efba8eff971a716ee178ae492f34c07844b",
+          state: "success",
+          context: "block-merge-based-on-time",
+          description: "The PR could be merged",
+          target_url: undefined,
+        })
+        expect(octokit.rest.repos.createCommitStatus).not.toHaveBeenCalledWith(
+          // It's already been success
+          expect.objectContaining({
+            sha: "f7ef543f6bf7d321117817743d8e4f0c4fb8136f",
+          })
+        )
+        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(2, {
+          owner: "foo",
+          repo: "special-repo",
+          sha: "1a097c106ca94999dee6249ba3e8c09190be9304",
+          state: "success",
+          context: "block-merge-based-on-time",
+          description: "The PR could be merged",
+          target_url: undefined,
+        })
+        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(3, {
+          owner: "foo",
+          repo: "special-repo",
+          sha: "69c87dcf047328c682ede7914d84fbcf422bcbc8",
+          state: "success",
+          context: "block-merge-based-on-time",
+          description: "The PR could be merged",
+          target_url: undefined,
+        })
+      })
+    })
+
+    describe("when base-branches includes (default) and regular expressions", () => {
+      beforeEach(() => {
+        Object.defineProperty(github.context, "eventName", { value: event })
+        getInput.mockClear()
+        getInput = jest.spyOn(core, "getInput").mockImplementation(
+          (name) =>
+            ({
+              token: "abc",
+              after: "12:20",
+              before: "16:00",
+              timezone: "Pacific/Honolulu",
+              "prohibited-days-dates": "Sunday, 2021-07-01",
+              "no-block-label": "Emergency",
+              "commit-status-context": "",
+              "commit-status-description-with-success": "",
+              "commit-status-description-while-blocking": "",
+              "commit-status-url": "",
+              "base-branches": "(default), develop, /^feature\\/.*/",
+            }[name] as any)
+        )
+
+        jest.spyOn(github.context, "repo", "get").mockReturnValue({ owner: "foo", repo: "special-repo" } as any)
+        octokit.graphql.mockResolvedValueOnce({
+          repository: {
+            defaultBranchRef: {
+              name: "main",
+            },
+          },
+        })
+        octokit.graphql.mockResolvedValueOnce({
+          repository: {
+            pullRequests: {
+              pageInfo: {
+                hasNextPage: true,
+                endCursor: "cur1",
+              },
+              edges: [
+                {
+                  cursor: "cur1",
+                  node: {
+                    id: "id1",
+                    number: 99,
+                    title: "ABC99",
+                    baseRef: {
+                      name: "main",
+                    },
+                    labels: {
+                      edges: [],
+                    },
+                    commits: {
+                      edges: [
+                        {
+                          node: {
+                            commit: {
+                              oid: "ABC99-commit1",
+                              message: "ABC99",
+                              status: null,
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        })
+        octokit.graphql.mockResolvedValueOnce({
+          repository: {
+            pullRequests: {
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: "cur2",
+              },
+              edges: [
+                {
+                  cursor: "cur2",
+                  node: {
+                    id: "id2",
+                    number: 98,
+                    title: "ABC98",
+                    baseRef: {
+                      name: "develop",
+                    },
+                    labels: {
+                      edges: [],
+                    },
+                    commits: {
+                      edges: [
+                        {
+                          node: {
+                            commit: {
+                              oid: "c2",
+                              message: "ABC98",
+                              status: null,
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  cursor: "cur3",
+                  node: {
+                    id: "cur3",
+                    number: 97,
+                    title: "ABC97",
+                    baseRef: {
+                      name: "feature/one",
+                    },
+                    labels: {
+                      edges: [],
+                    },
+                    commits: {
+                      edges: [
+                        {
+                          node: {
+                            commit: {
+                              oid: "c3",
+                              message: "ABC97",
+                              status: null,
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  cursor: "cur4",
+                  node: {
+                    id: "id4",
+                    number: 96,
+                    title: "ABC96",
+                    baseRef: {
+                      name: "misc/abc",
+                    },
+                    labels: {
+                      edges: [],
+                    },
+                    commits: {
+                      edges: [
+                        {
+                          node: {
+                            commit: {
+                              oid: "c4",
+                              message: "ABC96",
+                              status: null,
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  cursor: "cur5",
+                  node: {
+                    id: "id5",
+                    number: 95,
+                    title: "ABC95",
+                    baseRef: {
+                      name: "feature/two",
+                    },
+                    labels: {
+                      edges: [],
+                    },
+                    commits: {
+                      edges: [
+                        {
+                          node: {
+                            commit: {
+                              oid: "c5",
+                              message: "ABC95",
+                              status: null,
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  cursor: "cur6",
+                  node: {
+                    id: "id6",
+                    number: 94,
+                    title: "ABC94",
+                    baseRef: {
+                      name: "main",
+                    },
+                    labels: {
+                      edges: [],
+                    },
+                    commits: {
+                      edges: [
+                        {
+                          node: {
+                            commit: {
+                              oid: "c6",
+                              message: "ABC94",
+                              status: null,
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        })
+      })
+
+      test("excludes pull requests the base branch of which does not match", async () => {
+        jest.setSystemTime(new Date("2021-06-17T13:30:00-10:00"))
+        await run()
+        expect(octokit.graphql).toHaveBeenNthCalledWith(1, expect.any(String), {
+          owner: "foo",
+          repo: "special-repo",
+        })
+        expect(octokit.graphql).toHaveBeenNthCalledWith(2, expect.any(String), {
+          owner: "foo",
+          repo: "special-repo",
+          after: null,
+        })
+        expect(octokit.graphql).toHaveBeenNthCalledWith(3, expect.any(String), {
+          owner: "foo",
+          repo: "special-repo",
+          after: "cur1",
+        })
+        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(1, {
+          owner: "foo",
+          repo: "special-repo",
+          sha: "ABC99-commit1",
+          state: "pending",
+          context: "block-merge-based-on-time",
+          description: "The PR can't be merged based on time, which is due to your organization's policy",
+          target_url: undefined,
+        })
+        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(2, {
+          owner: "foo",
+          repo: "special-repo",
+          sha: "c2",
+          state: "pending",
+          context: "block-merge-based-on-time",
+          description: "The PR can't be merged based on time, which is due to your organization's policy",
+          target_url: undefined,
+        })
+        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(3, {
+          owner: "foo",
+          repo: "special-repo",
+          sha: "c3",
+          state: "pending",
+          context: "block-merge-based-on-time",
+          description: "The PR can't be merged based on time, which is due to your organization's policy",
+          target_url: undefined,
+        })
+        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(4, {
+          owner: "foo",
+          repo: "special-repo",
+          sha: "c5",
+          state: "pending",
+          context: "block-merge-based-on-time",
+          description: "The PR can't be merged based on time, which is due to your organization's policy",
+          target_url: undefined,
+        })
+        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(5, {
+          owner: "foo",
+          repo: "special-repo",
+          sha: "c6",
+          state: "pending",
+          context: "block-merge-based-on-time",
+          description: "The PR can't be merged based on time, which is due to your organization's policy",
+          target_url: undefined,
+        })
+        expect(octokit.rest.repos.createCommitStatus).not.toHaveBeenCalledWith({
+          owner: "foo",
+          repo: "special-repo",
+          sha: "c4",
+          state: "pending",
+          context: "block-merge-based-on-time",
+          description: "The PR can't be merged based on time, which is due to your organization's policy",
+          target_url: undefined,
+        })
       })
     })
   })

--- a/__tests__/should-block.ts
+++ b/__tests__/should-block.ts
@@ -80,7 +80,8 @@ describe("shouldBlock", () => {
       jest.setSystemTime(new Date(now))
       const inSpy = jest.spyOn(core, "getInput")
       inSpy.mockImplementation(
-        (name) => ({ after, before, timezone, "prohibited-days-dates": prohibited }[name] as any)
+        (name) =>
+          ({ after, before, timezone, "prohibited-days-dates": prohibited, "base-branches": "/^.*$/" }[name] as any)
       )
 
       const inputs = new Inputs()

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
   timezone:
     description: Time zone to use
     required: true
+  base-branches:
+    description: The comma-separated base branches of pull requests. This tool will block only pull requests the base branches of which are listed in this parameter. You can set regular expressions surrounding with `/` like `/staging\/.*/` and just set string literals like `develop`. Also, the value `(default)` is acceptable, which means pull requests that will be merged into the default branch will be blocked. The default value is `/^.*$/` for backward compatibility.
+    required: false
+    default: "/^.*$/"
   prohibited-days-dates:
     description: The comma-separated days or dates to stop blocking merge for all day. You can also specify regional holidays with special syntax, such as "H:St. Barthélemy" and "BH:St. Barthélemy", which stand for "holidays of St. Barthélemy" and "before holidays of St. Barthélemy." The word after "H:" or "BH:" is a region name that is listed in `src/holidays.json` as a JSON key. For example, the value could be "Sunday, 2021-08-01, 2021-08-06/2021-08-10, H:Côte d’Ivoire"
     required: false

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -16,6 +16,7 @@ export class Inputs {
   public readonly commitStatusDescriptionWithSuccess: string
   public readonly commitStatusDescriptionWhileBlocking: string
   public readonly commitStatusURL: string | null
+  private readonly rawBaseBranches: string[]
 
   constructor() {
     this.token = getInput("token", { required: true })
@@ -37,6 +38,20 @@ export class Inputs {
     )
     // NOTE: If the string is empty, we're not sure where we should refer to. So, `||` is appropriate here instead of `??`.
     this.commitStatusURL = getInput("commit-status-url") || null
+    this.rawBaseBranches = getInput("base-branches")
+      .split(/,\s*/)
+      .filter((v) => v !== "")
+  }
+
+  public baseBranches(defaultBranch: string): RegExp[] {
+    return this.rawBaseBranches.map((v) => {
+      if (v === "(default)") {
+        return new RegExp(`^${escapeRegExpCharacters(defaultBranch)}$`)
+      } else if (v.startsWith("/") && v.endsWith("/")) {
+        return new RegExp(v.replace(/^\/(.*)\/$/, "$1"))
+      }
+      return new RegExp(`^${escapeRegExpCharacters(v)}$`)
+    })
   }
 }
 
@@ -163,4 +178,10 @@ function prohibitedDaysDates(zone: Zone): DaysDates {
  */
 function stringOr(str: string, alt: string): string {
   return str || alt
+}
+
+// NOTE: I followed this guide.
+//       https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
+function escapeRegExpCharacters(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }


### PR DESCRIPTION
Close #86 

Some users might want this tool not to block pull requests that will be merged into non-default branches. Or, they just want to prevent pull requests from being merged into specific branches, such as `develop`.

This patch introduces `base-branches` to support such a feature.  Note `base-branches` parameter is set with `"/^.*$/"` by default for backward compatibility. If you want this tool to block only pull requests that will be merged into the default branch, `"(default)"` should be set for `base-branches`.