### PR TITLE
[Fix] Always run `createCommitStatus` at the pull request event

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13900,25 +13900,15 @@ function handlePull(inputs, payload) {
             state = "pending";
             description = inputs.commitStatusDescriptionWhileBlocking;
         }
-        const statuses = yield octokit.rest.repos
-            .listCommitStatusesForRef({
+        octokit.rest.repos.createCommitStatus({
             owner,
             repo,
-            ref: sha,
-            per_page: 100,
-        })
-            .then((res) => res.data.filter((d) => d.context === context && d.state === state));
-        if (statuses.length === 0) {
-            octokit.rest.repos.createCommitStatus({
-                owner,
-                repo,
-                sha,
-                state,
-                context,
-                description,
-                target_url,
-            });
-        }
+            sha,
+            state,
+            context,
+            description,
+            target_url,
+        });
     });
 }
 function fetchDefaultBranch(inputs, owner, repo) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -79,25 +79,15 @@ async function handlePull(inputs: Inputs, payload: any): Promise<void> {
     description = inputs.commitStatusDescriptionWhileBlocking
   }
 
-  const statuses = await octokit.rest.repos
-    .listCommitStatusesForRef({
-      owner,
-      repo,
-      ref: sha,
-      per_page: 100,
-    })
-    .then((res) => res.data.filter((d) => d.context === context && d.state === state))
-  if (statuses.length === 0) {
-    octokit.rest.repos.createCommitStatus({
-      owner,
-      repo,
-      sha,
-      state,
-      context,
-      description,
-      target_url,
-    })
-  }
+  octokit.rest.repos.createCommitStatus({
+    owner,
+    repo,
+    sha,
+    state,
+    context,
+    description,
+    target_url,
+  })
 }
 
 interface DefaultBranchResponse {


### PR DESCRIPTION
This tool should run when the action of pull request is `labeled` or
`unlabeled`, so it's not appropriate to see the list of commit statuses
for the head sha.

First, I made it check old commit statuses to avoid excessive
`createCommitStatus` API, but such cases might be edge cases. That's why
I ditched the feature with this patch.