### PR TITLE
[Refactor] Add github module, which will be used later

### DIFF
--- a/__tests__/github.ts
+++ b/__tests__/github.ts
@@ -1,0 +1,342 @@
+import { createCommitStatus, defaultBranch, pull, pulls } from "../src/github"
+
+describe("createCommitStatus", () => {
+  test("creates a commit status to make it pending", async () => {
+    const pull = {
+      owner: "Foo",
+      repo: "bar",
+      number: 3,
+      baseBranch: "develop",
+      sha: "c1",
+      labels: ["bug"],
+    }
+    const octokit: any = {
+      rest: {
+        repos: {
+          createCommitStatus: jest.fn(),
+        },
+      },
+    }
+    const inputs: any = {
+      commitStatusURL: null,
+      commitStatusContext: "blocker",
+      commitStatusDescriptionWithSuccess: "You can merge",
+      commitStatusDescriptionWhileBlocking: "No merge!",
+    }
+    await createCommitStatus(octokit, pull, inputs, "pending")
+    expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(1, {
+      owner: "Foo",
+      repo: "bar",
+      sha: "c1",
+      state: "pending",
+      context: "blocker",
+      description: "No merge!",
+      target_url: undefined,
+    })
+  })
+
+  test("creates a commit status to make it success", async () => {
+    const pull = {
+      owner: "Foo",
+      repo: "bar",
+      number: 3,
+      baseBranch: "develop",
+      sha: "c1",
+      labels: ["bug"],
+    }
+    const octokit: any = {
+      rest: {
+        repos: {
+          createCommitStatus: jest.fn(),
+        },
+      },
+    }
+    const inputs: any = {
+      commitStatusURL: "http://example.com",
+      commitStatusContext: "blocker",
+      commitStatusDescriptionWithSuccess: "You can merge",
+      commitStatusDescriptionWhileBlocking: "No merge!",
+    }
+    await createCommitStatus(octokit, pull, inputs, "success")
+    expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(1, {
+      owner: "Foo",
+      repo: "bar",
+      sha: "c1",
+      state: "success",
+      context: "blocker",
+      description: "You can merge",
+      target_url: "http://example.com",
+    })
+  })
+
+  test("does not create a commit status because the specified sha has been the desired state: pending", async () => {
+    const pull = {
+      owner: "Foo",
+      repo: "bar",
+      number: 3,
+      baseBranch: "develop",
+      sha: "c1",
+      labels: ["bug"],
+      state: "pending",
+    }
+    const octokit: any = {
+      rest: {
+        repos: {
+          createCommitStatus: jest.fn(),
+        },
+      },
+    }
+    const inputs: any = {
+      commitStatusURL: null,
+      commitStatusContext: "blocker",
+      commitStatusDescriptionWithSuccess: "You can merge",
+      commitStatusDescriptionWhileBlocking: "No merge!",
+    }
+    await createCommitStatus(octokit, pull, inputs, "pending")
+    expect(octokit.rest.repos.createCommitStatus).not.toHaveBeenCalled()
+  })
+
+  test("does not create a commit status because the specified sha has been the desired state: success", async () => {
+    const pull = {
+      owner: "Foo",
+      repo: "bar",
+      number: 3,
+      baseBranch: "develop",
+      sha: "c1",
+      labels: ["bug"],
+      state: "success",
+    }
+    const octokit: any = {
+      rest: {
+        repos: {
+          createCommitStatus: jest.fn(),
+        },
+      },
+    }
+    const inputs: any = {
+      commitStatusURL: "https://www.example.com",
+      commitStatusContext: "blocker",
+      commitStatusDescriptionWithSuccess: "You can merge",
+      commitStatusDescriptionWhileBlocking: "No merge!",
+    }
+    await createCommitStatus(octokit, pull, inputs, "success")
+    expect(octokit.rest.repos.createCommitStatus).not.toHaveBeenCalled()
+  })
+})
+
+describe("defaultBranch", () => {
+  test("fetches the default branch", async () => {
+    const octokit: any = {
+      graphql: jest.fn(() => ({ repository: { defaultBranchRef: { name: "main" } } })),
+    }
+    const result = await defaultBranch(octokit, "Foo", "bar")
+    expect(result).toEqual("main")
+    expect(octokit.graphql).toHaveBeenNthCalledWith(1, expect.any(String), { owner: "Foo", repo: "bar" })
+  })
+})
+
+describe("pull", () => {
+  test("fetches the pull request without commit statuses", async () => {
+    const octokit: any = {
+      graphql: jest.fn(() => ({
+        repository: {
+          defaultBranchRef: { name: "main" },
+          pullRequest: {
+            baseRefName: "develop",
+            commits: {
+              edges: [{ node: { commit: { oid: "c1" } } }],
+            },
+            labels: {
+              edges: [{ node: { name: "bug" } }],
+            },
+          },
+        },
+      })),
+    }
+    const result = await pull(octokit, "Foo", "bar", "blocker", 3)
+    expect(result).toEqual({
+      defaultBranch: "main",
+      pull: {
+        owner: "Foo",
+        repo: "bar",
+        number: 3,
+        baseBranch: "develop",
+        sha: "c1",
+        labels: ["bug"],
+      },
+    })
+    expect(octokit.graphql).toHaveBeenNthCalledWith(1, expect.any(String), {
+      owner: "Foo",
+      repo: "bar",
+      contextName: "blocker",
+      pullNumber: 3,
+    })
+  })
+
+  test("fetches the pull request with commit statuses", async () => {
+    const octokit: any = {
+      graphql: jest.fn(() => ({
+        repository: {
+          defaultBranchRef: { name: "main" },
+          pullRequest: {
+            baseRefName: "develop",
+            commits: {
+              edges: [{ node: { commit: { oid: "c3", status: { context: { state: "pending" } } } } }],
+            },
+            labels: {
+              edges: [],
+            },
+          },
+        },
+      })),
+    }
+    const result = await pull(octokit, "Foo", "bar", "blocker", 5)
+    expect(result).toEqual({
+      defaultBranch: "main",
+      pull: {
+        owner: "Foo",
+        repo: "bar",
+        number: 5,
+        baseBranch: "develop",
+        sha: "c3",
+        labels: [],
+        state: "pending",
+      },
+    })
+    expect(octokit.graphql).toHaveBeenNthCalledWith(1, expect.any(String), {
+      owner: "Foo",
+      repo: "bar",
+      contextName: "blocker",
+      pullNumber: 5,
+    })
+  })
+
+  test("fetches the pull request with commit statuses, but its context does not exist", async () => {
+    const octokit: any = {
+      graphql: jest.fn(() => ({
+        repository: {
+          defaultBranchRef: { name: "main" },
+          pullRequest: {
+            baseRefName: "develop",
+            commits: {
+              edges: [{ node: { commit: { oid: "c5", status: { context: null } } } }],
+            },
+            labels: {
+              edges: [],
+            },
+          },
+        },
+      })),
+    }
+    const result = await pull(octokit, "Foo", "bar", "blocker", 7)
+    expect(result).toEqual({
+      defaultBranch: "main",
+      pull: {
+        owner: "Foo",
+        repo: "bar",
+        number: 7,
+        baseBranch: "develop",
+        sha: "c5",
+        labels: [],
+      },
+    })
+    expect(octokit.graphql).toHaveBeenNthCalledWith(1, expect.any(String), {
+      owner: "Foo",
+      repo: "bar",
+      contextName: "blocker",
+      pullNumber: 7,
+    })
+  })
+})
+
+describe("pulls", () => {
+  test("fetches the pull requests", async () => {
+    const octokit: any = {
+      graphql: jest
+        .fn()
+        .mockResolvedValueOnce({
+          repository: {
+            defaultBranchRef: { name: "main" },
+            pullRequests: {
+              pageInfo: {
+                hasNextPage: true,
+                endCursor: "cur1",
+              },
+              edges: [
+                {
+                  cursor: "cur1",
+                  node: {
+                    number: 10,
+                    title: "#10",
+                    baseRefName: "main",
+                    labels: { edges: [{ node: { name: "bug" } }] },
+                    commits: {
+                      edges: [{ node: { commit: { oid: "c10", status: { context: { state: "pending" } } } } }],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          repository: {
+            defaultBranchRef: { name: "main" },
+            pullRequests: {
+              pageInfo: {
+                hasNextPage: false,
+                endCursor: "cur2",
+              },
+              edges: [
+                {
+                  cursor: "cur2",
+                  node: {
+                    number: 9,
+                    title: "#9",
+                    baseRefName: "develop",
+                    labels: { edges: [] },
+                    commits: {
+                      edges: [{ node: { commit: { oid: "c9", status: { context: { state: "success" } } } } }],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        }),
+    }
+    const result = await pulls(octokit, "Foo", "bar", "blocker!")
+    expect(result).toEqual([
+      {
+        owner: "Foo",
+        repo: "bar",
+        number: 10,
+        baseBranch: "main",
+        sha: "c10",
+        labels: ["bug"],
+        state: "pending",
+      },
+      {
+        owner: "Foo",
+        repo: "bar",
+        number: 9,
+        baseBranch: "develop",
+        sha: "c9",
+        labels: [],
+        state: "success",
+      },
+    ])
+    expect(octokit.graphql).toHaveBeenNthCalledWith(1, expect.any(String), {
+      owner: "Foo",
+      repo: "bar",
+      contextName: "blocker!",
+      after: null,
+    })
+    expect(octokit.graphql).toHaveBeenNthCalledWith(2, expect.any(String), {
+      owner: "Foo",
+      repo: "bar",
+      contextName: "blocker!",
+      after: "cur1",
+    })
+  })
+})

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,0 +1,266 @@
+import { GitHub } from "@actions/github/lib/utils"
+import { Inputs } from "./inputs"
+
+export interface PullRequestStatus {
+  readonly owner: string
+  readonly repo: string
+  readonly number: number
+  readonly baseBranch: string
+  readonly sha: string
+  readonly labels: string[]
+  readonly state?: string
+}
+
+interface Pull {
+  readonly number: number
+  readonly title: string
+  readonly baseRefName: string
+  readonly labels: {
+    readonly edges: {
+      readonly node: {
+        readonly name: string
+      }
+    }[]
+  }
+  readonly commits: {
+    readonly edges: {
+      readonly node: {
+        readonly commit: {
+          readonly oid: string
+          readonly message: string
+          readonly status: {
+            readonly context: {
+              readonly state: string
+            } | null
+          } | null
+        }
+      }
+    }[]
+  }
+}
+
+interface RepositoryResponse {
+  readonly repository: {
+    readonly defaultBranchRef: {
+      readonly name: string
+    }
+  }
+}
+
+interface PullResponse {
+  readonly repository: {
+    readonly defaultBranchRef: {
+      readonly name: string
+    }
+    readonly pullRequest: Pull
+  }
+}
+
+interface PullsResponse {
+  readonly repository: {
+    readonly defaultBranchRef: {
+      readonly name: string
+    }
+    readonly pullRequests: {
+      readonly pageInfo: {
+        readonly hasNextPage: boolean
+        readonly endCursor: string | null
+      }
+      readonly edges: {
+        readonly node: Pull
+      }[]
+    }
+  }
+}
+
+export async function createCommitStatus(
+  octokit: InstanceType<typeof GitHub>,
+  pullRequestStatus: PullRequestStatus,
+  inputs: Inputs,
+  state: "success" | "pending"
+): Promise<void> {
+  if (pullRequestStatus.state === state) {
+    return
+  }
+  const { owner, repo, sha } = pullRequestStatus
+  const targetUrl = inputs.commitStatusURL ?? undefined
+  const context = inputs.commitStatusContext
+  let description: string
+  switch (state) {
+    case "success": {
+      description = inputs.commitStatusDescriptionWithSuccess
+      break
+    }
+    case "pending": {
+      description = inputs.commitStatusDescriptionWhileBlocking
+      break
+    }
+  }
+  octokit.rest.repos.createCommitStatus({
+    owner,
+    repo,
+    sha,
+    state,
+    context,
+    description,
+    target_url: targetUrl,
+  })
+}
+
+export async function defaultBranch(
+  octokit: InstanceType<typeof GitHub>,
+  owner: string,
+  repo: string
+): Promise<string> {
+  const result: RepositoryResponse = await octokit.graphql(
+    `
+query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    defaultBranchRef {
+      name
+    }
+  }
+}`,
+    { owner, repo }
+  )
+  return result.repository.defaultBranchRef.name
+}
+
+export async function pull(
+  octokit: InstanceType<typeof GitHub>,
+  owner: string,
+  repo: string,
+  contextName: string,
+  pullNumber: number
+): Promise<{ readonly defaultBranch: string; readonly pull: PullRequestStatus }> {
+  const result: PullResponse = await octokit.graphql(
+    `
+query($owner: String!, $repo: String!, $contextName, String!, $pullNumber: Int!) {
+  repository(owner: $owner, name: $repo) {
+    defaultBranchRef {
+      name
+    }
+    pullRequest(number: $pullNumber) {
+      number
+      title
+      baseRefName
+      labels(first: 100) {
+        edges {
+          node {
+            name
+          }
+        }
+      }
+      commits(last: 1) {
+        edges {
+          node {
+            commit {
+              oid
+              message
+              status {
+                context(name: $contextName) {
+                  state
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`,
+    { owner, repo, contextName, pullNumber }
+  )
+  const commit = result.repository.pullRequest.commits.edges[0]
+  if (commit == null) {
+    throw new Error("commit should be present")
+  }
+  const pull: PullRequestStatus = {
+    owner,
+    repo,
+    number: pullNumber,
+    baseBranch: result.repository.pullRequest.baseRefName,
+    sha: commit.node.commit.oid,
+    labels: result.repository.pullRequest.labels.edges.map(({ node: { name } }) => name),
+    state: commit.node.commit.status?.context?.state,
+  }
+  return {
+    defaultBranch: result.repository.defaultBranchRef.name,
+    pull,
+  }
+}
+
+export async function pulls(
+  octokit: InstanceType<typeof GitHub>,
+  owner: string,
+  repo: string,
+  contextName: string
+): Promise<PullRequestStatus[]> {
+  let after: string | null = null
+  let hasNextPage = true
+  let statuses: PullRequestStatus[] = []
+  while (hasNextPage) {
+    const result: PullsResponse = await octokit.graphql(
+      `
+query($owner: String!, $repo: String!, $contextName: String!, $after: String) {
+  repository(owner: $owner, name: $repo) {
+    defaultBranchRef {
+      name
+    }
+    pullRequests(after: $after, first: 100, states: OPEN, orderBy: { field: CREATED_AT, direction: DESC}) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        node {
+          number
+          title
+          baseRefName
+          labels(first: 100) {
+            edges {
+              node {
+                name
+              }
+            }
+          }
+          commits(last: 1) {
+            edges {
+              node {
+                commit {
+                  oid
+                  message
+                  status {
+                    context(name: $contextName) {
+                      state
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`,
+      { owner, repo, contextName, after }
+    )
+    hasNextPage = result.repository.pullRequests.pageInfo.hasNextPage
+    after = result.repository.pullRequests.pageInfo.endCursor
+
+    const data = result.repository.pullRequests.edges.flatMap(({ node: pr }) =>
+      pr.commits.edges.map(({ node: commit }) => ({
+        owner,
+        repo,
+        number: pr.number,
+        baseBranch: pr.baseRefName,
+        sha: commit.commit.oid,
+        labels: pr.labels.edges.map((l) => l.node.name),
+        state: commit.commit.status?.context?.state,
+      }))
+    )
+    statuses = [...statuses, ...data]
+  }
+  return statuses
+}


### PR DESCRIPTION
I want to refactor this tool.

This patch introduces `github` module to wrap API calls to GitHub. The reason I created is that I want to mock API responses in easier ways.