### PR TITLE
[Refactor] Use the new APIs to run for each pull request event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@actions/core": "^1.4.0",
         "@actions/github": "^5.0.0",
-        "@octokit/webhooks-definitions": "^3.67.3",
         "luxon": "^1.27.0"
       },
       "devDependencies": {
@@ -1148,12 +1147,6 @@
       "dependencies": {
         "@octokit/openapi-types": "^7.2.3"
       }
-    },
-    "node_modules/@octokit/webhooks-definitions": {
-      "version": "3.67.3",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks-definitions/-/webhooks-definitions-3.67.3.tgz",
-      "integrity": "sha512-do4Z1r2OVhuI0ihJhQ8Hg+yPWnBYEBNuFNCrvtPKoYT1w81jD7pBXgGe86lYuuNirkDHb0Nxt+zt4O5GiFJfgA==",
-      "deprecated": "Use @octokit/webhooks-types, @octokit/webhooks-schemas, or @octokit/webhooks-examples instead. See https://github.com/octokit/webhooks/issues/447"
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -6694,11 +6687,6 @@
       "requires": {
         "@octokit/openapi-types": "^7.2.3"
       }
-    },
-    "@octokit/webhooks-definitions": {
-      "version": "3.67.3",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks-definitions/-/webhooks-definitions-3.67.3.tgz",
-      "integrity": "sha512-do4Z1r2OVhuI0ihJhQ8Hg+yPWnBYEBNuFNCrvtPKoYT1w81jD7pBXgGe86lYuuNirkDHb0Nxt+zt4O5GiFJfgA=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@actions/core": "^1.4.0",
     "@actions/github": "^5.0.0",
-    "@octokit/webhooks-definitions": "^3.67.3",
     "luxon": "^1.27.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This patch uses the new APIs introduced on
https://github.com/yykamei/block-merge-based-on-time/pull/118

First, I want to use it for the `pull_request` event.