### PR TITLE
[Refactor] Use the new APIs to run for scheduled event

### DIFF
--- a/__tests__/run.ts
+++ b/__tests__/run.ts
@@ -5,34 +5,10 @@ import { run } from "../src/run"
 import { Inputs } from "../src/inputs"
 
 describe("run", () => {
-  const octokit = {
-    graphql: jest.fn(),
-    rest: {
-      repos: {
-        createCommitStatus: jest.fn(),
-      },
-    },
-  }
-  let getInput: any
+  const octokit = jest.fn()
 
   beforeAll(() => {
     jest.useFakeTimers()
-    getInput = jest.spyOn(core, "getInput").mockImplementation(
-      (name) =>
-        ({
-          token: "abc",
-          after: "12:20",
-          before: "16:00",
-          timezone: "Pacific/Honolulu",
-          "prohibited-days-dates": "Sunday, 2021-07-01",
-          "no-block-label": "Emergency",
-          "commit-status-context": "",
-          "commit-status-description-with-success": "",
-          "commit-status-description-while-blocking": "",
-          "commit-status-url": "",
-          "base-branches": "/^.*$/",
-        }[name] as any)
-    )
     jest.spyOn(github, "getOctokit").mockImplementation(() => octokit as any)
   })
 
@@ -41,567 +17,84 @@ describe("run", () => {
   })
 
   describe.each([["schedule"], ["workflow_dispatch"]])("when the event is %s", (event) => {
-    describe("when base-branches is the default value", () => {
-      beforeEach(() => {
-        Object.defineProperty(github.context, "eventName", { value: event })
-        jest.spyOn(github.context, "repo", "get").mockReturnValue({ owner: "foo", repo: "special-repo" } as any)
-        octokit.graphql.mockResolvedValueOnce({
-          repository: {
-            defaultBranchRef: {
-              name: "main",
-            },
-          },
-        })
-        octokit.graphql.mockResolvedValueOnce({
-          repository: {
-            pullRequests: {
-              pageInfo: {
-                hasNextPage: true,
-                endCursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyODoyNiswOTowMM4oKH4V",
-              },
-              edges: [
-                {
-                  cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyODoyNiswOTowMM4oKH4V",
-                  node: {
-                    id: "MDExOlB1bGxSZXF1ZXN0NjczNzQyMzU3",
-                    number: 13,
-                    title: "Create c.js",
-                    baseRef: {
-                      name: "main",
-                    },
-                    labels: {
-                      edges: [
-                        {
-                          node: {
-                            name: "Emergency",
-                          },
-                        },
-                      ],
-                    },
-                    commits: {
-                      edges: [
-                        {
-                          node: {
-                            commit: {
-                              oid: "a7ba8efba8eff971a716ee178ae492f34c07844b",
-                              message: "Update c.js",
-                              status: null,
-                            },
-                          },
-                        },
-                      ],
-                    },
-                  },
-                },
-              ],
-            },
-          },
-        })
-        octokit.graphql.mockResolvedValueOnce({
-          repository: {
-            pullRequests: {
-              pageInfo: {
-                hasNextPage: false,
-                endCursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNS0zMVQwOToyNToxOSswOTowMM4nNe7z",
-              },
-              edges: [
-                {
-                  cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyNjozMSswOTowMM4oKHtr",
-                  node: {
-                    id: "MDExOlB1bGxSZXF1ZXN0NjczNzQxNjc1",
-                    number: 12,
-                    title: "Create b.js",
-                    baseRef: {
-                      name: "main",
-                    },
-                    labels: {
-                      edges: [],
-                    },
-                    commits: {
-                      edges: [
-                        {
-                          node: {
-                            commit: {
-                              oid: "f7ef543f6bf7d321117817743d8e4f0c4fb8136f",
-                              message: "Create b.js",
-                              status: {
-                                contexts: [
-                                  {
-                                    context: "block-merge-based-on-time",
-                                    state: "SUCCESS",
-                                  },
-                                ],
-                              },
-                            },
-                          },
-                        },
-                      ],
-                    },
-                  },
-                },
-                {
-                  cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyNjowMSswOTowMM4oKHq4",
-                  node: {
-                    id: "MDExOlB1bGxSZXF1ZXN0NjczNzQxNDk2",
-                    number: 11,
-                    title: "Create a.js",
-                    baseRef: {
-                      name: "main",
-                    },
-                    labels: {
-                      edges: [],
-                    },
-                    commits: {
-                      edges: [
-                        {
-                          node: {
-                            commit: {
-                              oid: "1a097c106ca94999dee6249ba3e8c09190be9304",
-                              message: "Create a.js",
-                              status: null,
-                            },
-                          },
-                        },
-                      ],
-                    },
-                  },
-                },
-                {
-                  cursor: "Y3Vyc29yOnYyOpK5MjAyMS0wNS0zMVQwOToyNToxOSswOTowMM4nNe7z",
-                  node: {
-                    id: "MDExOlB1bGxSZXF1ZXN0NjU3ODQ2MDAz",
-                    number: 10,
-                    title: "Add empty files",
-                    baseRef: {
-                      name: "develop",
-                    },
-                    labels: {
-                      edges: [],
-                    },
-                    commits: {
-                      edges: [
-                        {
-                          node: {
-                            commit: {
-                              oid: "69c87dcf047328c682ede7914d84fbcf422bcbc8",
-                              message: "fixup! Add empty files",
-                              status: null,
-                            },
-                          },
-                        },
-                      ],
-                    },
-                  },
-                },
-              ],
-            },
-          },
-        })
-      })
-      test("makes all pull requests pending, aside from ones with labels", async () => {
-        jest.setSystemTime(new Date("2021-06-17T13:30:00-10:00"))
-        await run()
-        expect(octokit.graphql).toHaveBeenNthCalledWith(1, expect.any(String), {
-          owner: "foo",
-          repo: "special-repo",
-        })
-        expect(octokit.graphql).toHaveBeenNthCalledWith(2, expect.any(String), {
-          owner: "foo",
-          repo: "special-repo",
-          after: null,
-        })
-        expect(octokit.graphql).toHaveBeenNthCalledWith(3, expect.any(String), {
-          owner: "foo",
-          repo: "special-repo",
-          after: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyODoyNiswOTowMM4oKH4V",
-        })
-        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(1, {
-          owner: "foo",
-          repo: "special-repo",
-          sha: "a7ba8efba8eff971a716ee178ae492f34c07844b",
-          state: "success",
-          context: "block-merge-based-on-time",
-          description: "The PR could be merged",
-          target_url: undefined,
-        })
-        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(2, {
-          owner: "foo",
-          repo: "special-repo",
-          sha: "f7ef543f6bf7d321117817743d8e4f0c4fb8136f",
-          state: "pending",
-          context: "block-merge-based-on-time",
-          description: "The PR can't be merged based on time, which is due to your organization's policy",
-          target_url: undefined,
-        })
-        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(3, {
-          owner: "foo",
-          repo: "special-repo",
-          sha: "1a097c106ca94999dee6249ba3e8c09190be9304",
-          state: "pending",
-          context: "block-merge-based-on-time",
-          description: "The PR can't be merged based on time, which is due to your organization's policy",
-          target_url: undefined,
-        })
-        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(4, {
-          owner: "foo",
-          repo: "special-repo",
-          sha: "69c87dcf047328c682ede7914d84fbcf422bcbc8",
-          state: "pending",
-          context: "block-merge-based-on-time",
-          description: "The PR can't be merged based on time, which is due to your organization's policy",
-          target_url: undefined,
-        })
-      })
-      test("makes all pull requests success but don't create status if it's already success", async () => {
-        jest.setSystemTime(new Date("2021-06-17T11:30:00-10:00"))
-        await run()
-        expect(octokit.graphql).toHaveBeenNthCalledWith(1, expect.any(String), {
-          owner: "foo",
-          repo: "special-repo",
-        })
-        expect(octokit.graphql).toHaveBeenNthCalledWith(2, expect.any(String), {
-          owner: "foo",
-          repo: "special-repo",
-          after: null,
-        })
-        expect(octokit.graphql).toHaveBeenNthCalledWith(3, expect.any(String), {
-          owner: "foo",
-          repo: "special-repo",
-          after: "Y3Vyc29yOnYyOpK5MjAyMS0wNi0xOVQwNjoyODoyNiswOTowMM4oKH4V",
-        })
-        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(1, {
-          owner: "foo",
-          repo: "special-repo",
-          sha: "a7ba8efba8eff971a716ee178ae492f34c07844b",
-          state: "success",
-          context: "block-merge-based-on-time",
-          description: "The PR could be merged",
-          target_url: undefined,
-        })
-        expect(octokit.rest.repos.createCommitStatus).not.toHaveBeenCalledWith(
-          // It's already been success
-          expect.objectContaining({
-            sha: "f7ef543f6bf7d321117817743d8e4f0c4fb8136f",
-          })
-        )
-        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(2, {
-          owner: "foo",
-          repo: "special-repo",
-          sha: "1a097c106ca94999dee6249ba3e8c09190be9304",
-          state: "success",
-          context: "block-merge-based-on-time",
-          description: "The PR could be merged",
-          target_url: undefined,
-        })
-        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(3, {
-          owner: "foo",
-          repo: "special-repo",
-          sha: "69c87dcf047328c682ede7914d84fbcf422bcbc8",
-          state: "success",
-          context: "block-merge-based-on-time",
-          description: "The PR could be merged",
-          target_url: undefined,
-        })
-      })
+    let inputs = {
+      token: "abc",
+      after: "12:20",
+      before: "16:00",
+      timezone: "Pacific/Honolulu",
+      "prohibited-days-dates": "Sunday, 2021-07-01",
+      "no-block-label": "Emergency",
+      "commit-status-context": "BB",
+      "commit-status-description-with-success": "",
+      "commit-status-description-while-blocking": "",
+      "commit-status-url": "",
+    }
+
+    beforeEach(() => {
+      Object.defineProperty(github.context, "eventName", { value: event })
+      jest.spyOn(github.context, "repo", "get").mockReturnValue({ owner: "foo", repo: "special-repo" } as any)
     })
 
-    describe("when base-branches includes (default) and regular expressions", () => {
-      beforeEach(() => {
-        Object.defineProperty(github.context, "eventName", { value: event })
-        getInput.mockClear()
-        getInput = jest.spyOn(core, "getInput").mockImplementation(
+    test.each([
+      {
+        inputBaseBranches: "/^.*$/",
+        pulls: [
+          { baseBranch: "main", labels: ["foo", "bug"] } as any,
+          { baseBranch: "develop", labels: ["feature", "enhancement"] } as any,
+        ],
+        expectedStates: ["pending", "pending"],
+      },
+      {
+        inputBaseBranches: "(default)",
+        pulls: [
+          { baseBranch: "main", labels: ["foo", "bug"] } as any,
+          { baseBranch: "main", labels: ["Emergency", "bug"] } as any,
+          { baseBranch: "develop", labels: ["feature", "enhancement"] } as any,
+          { baseBranch: "feature/abc", labels: ["feature", "enhancement"] } as any,
+        ],
+        expectedStates: ["pending", "success", "success", "success"],
+      },
+      {
+        inputBaseBranches: "(default), staging, /feature/.*/",
+        pulls: [
+          { baseBranch: "main", labels: ["foo", "bug"] } as any,
+          { baseBranch: "main", labels: ["Emergency", "bug"] } as any,
+          { baseBranch: "develop", labels: ["feature", "enhancement"] } as any,
+          { baseBranch: "staging", labels: [] } as any,
+          { baseBranch: "staging", labels: ["Emergency"] } as any,
+          { baseBranch: "feature/abc", labels: ["feature", "enhancement"] } as any,
+          { baseBranch: "feature/foo", labels: ["Emergency", "enhancement"] } as any,
+        ],
+        expectedStates: ["pending", "success", "success", "pending", "success", "pending", "success"],
+      },
+    ])(
+      "creates commit statuses: $inputBaseBranches, $pulls, $expectedStates",
+      async ({ inputBaseBranches, pulls, expectedStates }) => {
+        jest.setSystemTime(new Date("2021-06-17T13:30:00-10:00"))
+        jest.spyOn(core, "getInput").mockImplementation(
           (name) =>
             ({
-              token: "abc",
-              after: "12:20",
-              before: "16:00",
-              timezone: "Pacific/Honolulu",
-              "prohibited-days-dates": "Sunday, 2021-07-01",
-              "no-block-label": "Emergency",
-              "commit-status-context": "",
-              "commit-status-description-with-success": "",
-              "commit-status-description-while-blocking": "",
-              "commit-status-url": "",
-              "base-branches": "(default), develop, /^feature\\/.*/",
+              ...inputs,
+              "base-branches": inputBaseBranches,
             }[name] as any)
         )
-
-        jest.spyOn(github.context, "repo", "get").mockReturnValue({ owner: "foo", repo: "special-repo" } as any)
-        octokit.graphql.mockResolvedValueOnce({
-          repository: {
-            defaultBranchRef: {
-              name: "main",
-            },
-          },
-        })
-        octokit.graphql.mockResolvedValueOnce({
-          repository: {
-            pullRequests: {
-              pageInfo: {
-                hasNextPage: true,
-                endCursor: "cur1",
-              },
-              edges: [
-                {
-                  cursor: "cur1",
-                  node: {
-                    id: "id1",
-                    number: 99,
-                    title: "ABC99",
-                    baseRef: {
-                      name: "main",
-                    },
-                    labels: {
-                      edges: [],
-                    },
-                    commits: {
-                      edges: [
-                        {
-                          node: {
-                            commit: {
-                              oid: "ABC99-commit1",
-                              message: "ABC99",
-                              status: null,
-                            },
-                          },
-                        },
-                      ],
-                    },
-                  },
-                },
-              ],
-            },
-          },
-        })
-        octokit.graphql.mockResolvedValueOnce({
-          repository: {
-            pullRequests: {
-              pageInfo: {
-                hasNextPage: false,
-                endCursor: "cur2",
-              },
-              edges: [
-                {
-                  cursor: "cur2",
-                  node: {
-                    id: "id2",
-                    number: 98,
-                    title: "ABC98",
-                    baseRef: {
-                      name: "develop",
-                    },
-                    labels: {
-                      edges: [],
-                    },
-                    commits: {
-                      edges: [
-                        {
-                          node: {
-                            commit: {
-                              oid: "c2",
-                              message: "ABC98",
-                              status: null,
-                            },
-                          },
-                        },
-                      ],
-                    },
-                  },
-                },
-                {
-                  cursor: "cur3",
-                  node: {
-                    id: "cur3",
-                    number: 97,
-                    title: "ABC97",
-                    baseRef: {
-                      name: "feature/one",
-                    },
-                    labels: {
-                      edges: [],
-                    },
-                    commits: {
-                      edges: [
-                        {
-                          node: {
-                            commit: {
-                              oid: "c3",
-                              message: "ABC97",
-                              status: null,
-                            },
-                          },
-                        },
-                      ],
-                    },
-                  },
-                },
-                {
-                  cursor: "cur4",
-                  node: {
-                    id: "id4",
-                    number: 96,
-                    title: "ABC96",
-                    baseRef: {
-                      name: "misc/abc",
-                    },
-                    labels: {
-                      edges: [],
-                    },
-                    commits: {
-                      edges: [
-                        {
-                          node: {
-                            commit: {
-                              oid: "c4",
-                              message: "ABC96",
-                              status: null,
-                            },
-                          },
-                        },
-                      ],
-                    },
-                  },
-                },
-                {
-                  cursor: "cur5",
-                  node: {
-                    id: "id5",
-                    number: 95,
-                    title: "ABC95",
-                    baseRef: {
-                      name: "feature/two",
-                    },
-                    labels: {
-                      edges: [],
-                    },
-                    commits: {
-                      edges: [
-                        {
-                          node: {
-                            commit: {
-                              oid: "c5",
-                              message: "ABC95",
-                              status: null,
-                            },
-                          },
-                        },
-                      ],
-                    },
-                  },
-                },
-                {
-                  cursor: "cur6",
-                  node: {
-                    id: "id6",
-                    number: 94,
-                    title: "ABC94",
-                    baseRef: {
-                      name: "main",
-                    },
-                    labels: {
-                      edges: [],
-                    },
-                    commits: {
-                      edges: [
-                        {
-                          node: {
-                            commit: {
-                              oid: "c6",
-                              message: "ABC94",
-                              status: null,
-                            },
-                          },
-                        },
-                      ],
-                    },
-                  },
-                },
-              ],
-            },
-          },
-        })
-      })
-
-      test("excludes pull requests the base branch of which does not match", async () => {
-        jest.setSystemTime(new Date("2021-06-17T13:30:00-10:00"))
+        const defaultBranch = jest.spyOn(api, "defaultBranch").mockImplementation(async () => "main")
+        const pullsCall = jest.spyOn(api, "pulls").mockImplementation(async () => pulls)
+        const createCommitStatus = jest.spyOn(api, "createCommitStatus").mockImplementation(async () => {})
         await run()
-        expect(octokit.graphql).toHaveBeenNthCalledWith(1, expect.any(String), {
-          owner: "foo",
-          repo: "special-repo",
+        expect(defaultBranch).toHaveBeenCalledWith(octokit, "foo", "special-repo")
+        expect(pullsCall).toHaveBeenCalledWith(octokit, "foo", "special-repo", "BB")
+        pulls.forEach((pull, idx) => {
+          expect(createCommitStatus).toHaveBeenCalledWith(octokit, pull, expect.any(Inputs), expectedStates[idx])
         })
-        expect(octokit.graphql).toHaveBeenNthCalledWith(2, expect.any(String), {
-          owner: "foo",
-          repo: "special-repo",
-          after: null,
-        })
-        expect(octokit.graphql).toHaveBeenNthCalledWith(3, expect.any(String), {
-          owner: "foo",
-          repo: "special-repo",
-          after: "cur1",
-        })
-        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(1, {
-          owner: "foo",
-          repo: "special-repo",
-          sha: "ABC99-commit1",
-          state: "pending",
-          context: "block-merge-based-on-time",
-          description: "The PR can't be merged based on time, which is due to your organization's policy",
-          target_url: undefined,
-        })
-        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(2, {
-          owner: "foo",
-          repo: "special-repo",
-          sha: "c2",
-          state: "pending",
-          context: "block-merge-based-on-time",
-          description: "The PR can't be merged based on time, which is due to your organization's policy",
-          target_url: undefined,
-        })
-        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(3, {
-          owner: "foo",
-          repo: "special-repo",
-          sha: "c3",
-          state: "pending",
-          context: "block-merge-based-on-time",
-          description: "The PR can't be merged based on time, which is due to your organization's policy",
-          target_url: undefined,
-        })
-        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(4, {
-          owner: "foo",
-          repo: "special-repo",
-          sha: "c5",
-          state: "pending",
-          context: "block-merge-based-on-time",
-          description: "The PR can't be merged based on time, which is due to your organization's policy",
-          target_url: undefined,
-        })
-        expect(octokit.rest.repos.createCommitStatus).toHaveBeenNthCalledWith(5, {
-          owner: "foo",
-          repo: "special-repo",
-          sha: "c6",
-          state: "pending",
-          context: "block-merge-based-on-time",
-          description: "The PR can't be merged based on time, which is due to your organization's policy",
-          target_url: undefined,
-        })
-        expect(octokit.rest.repos.createCommitStatus).not.toHaveBeenCalledWith({
-          owner: "foo",
-          repo: "special-repo",
-          sha: "c4",
-          state: "pending",
-          context: "block-merge-based-on-time",
-          description: "The PR can't be merged based on time, which is due to your organization's policy",
-          target_url: undefined,
-        })
-      })
-    })
+      }
+    )
   })
 
   describe("when the event is pull_request", () => {
     beforeEach(() => {
       Object.defineProperty(github.context, "eventName", { value: "pull_request" })
-      getInput.mockClear()
-      getInput = jest.spyOn(core, "getInput").mockImplementation(
+      jest.spyOn(core, "getInput").mockImplementation(
         (name) =>
           ({
             token: "abc",

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,7 +1,7 @@
 import { context, getOctokit } from "@actions/github"
 import { Inputs } from "./inputs"
 import { shouldBlock } from "./should-block"
-import { createCommitStatus, pull } from "./github"
+import { createCommitStatus, defaultBranch, pull, pulls } from "./github"
 
 export async function run(): Promise<void> {
   const inputs = new Inputs()
@@ -20,39 +20,20 @@ export async function run(): Promise<void> {
 async function handleAllPulls(inputs: Inputs): Promise<void> {
   const octokit = getOctokit(inputs.token)
   const { owner, repo } = context.repo
-  const defaultBranch = await fetchDefaultBranch(inputs, owner, repo)
-  const statuses = await fetchPullRequestStatuses(inputs, owner, repo, defaultBranch)
+  const branch = await defaultBranch(octokit, owner, repo)
+  const results = await pulls(octokit, owner, repo, inputs.commitStatusContext)
+  const expected = shouldBlock(inputs) ? "pending" : "success"
 
-  const runBulk = (state: "pending" | "success") => {
-    statuses.forEach((s) => {
-      let expected = state
-      let description =
-        state === "success" ? inputs.commitStatusDescriptionWithSuccess : inputs.commitStatusDescriptionWhileBlocking
-      if (s.labels.includes(inputs.noBlockLabel)) {
-        expected = "success"
-        description = inputs.commitStatusDescriptionWithSuccess
-      }
-      if (s.state?.toLowerCase() === expected) {
-        // We don't have to recreate commit status because the state has been already expected value.
-        return
-      }
-      octokit.rest.repos.createCommitStatus({
-        owner,
-        repo,
-        sha: s.sha,
-        state: expected,
-        context: inputs.commitStatusContext,
-        description,
-        target_url: inputs.commitStatusURL || undefined,
-      })
-    })
-  }
-
-  if (shouldBlock(inputs)) {
-    runBulk("pending")
-  } else {
-    runBulk("success")
-  }
+  results.forEach((pull) => {
+    // TODO: shouldBlock() should decide which labels and base branches should be treated as "no block."
+    const state =
+      inputs.baseBranches(branch).some((b) => b.test(pull.baseBranch)) &&
+      expected &&
+      !pull.labels.includes(inputs.noBlockLabel)
+        ? "pending"
+        : "success"
+    createCommitStatus(octokit, pull, inputs, state)
+  })
 }
 
 async function handlePull(inputs: Inputs): Promise<void> {
@@ -72,156 +53,4 @@ async function handlePull(inputs: Inputs): Promise<void> {
       ? "pending"
       : "success"
   return createCommitStatus(octokit, result.pull, inputs, state)
-}
-
-interface DefaultBranchResponse {
-  readonly repository: {
-    readonly defaultBranchRef: {
-      readonly name: string
-    }
-  }
-}
-
-interface StatusesResponse {
-  readonly repository: {
-    readonly pullRequests: {
-      readonly pageInfo: {
-        readonly hasNextPage: boolean
-        readonly endCursor: string | null
-      }
-      readonly edges: {
-        readonly node: {
-          readonly number: number
-          readonly title: string
-          readonly baseRef: {
-            readonly name: string
-          }
-          readonly labels: {
-            readonly edges: {
-              readonly node: {
-                readonly name: string
-              }
-            }[]
-          }
-          readonly commits: {
-            readonly edges: {
-              readonly node: {
-                readonly commit: {
-                  readonly oid: string
-                  readonly message: string
-                  readonly status: {
-                    readonly contexts: {
-                      readonly context: string
-                      readonly state: string
-                    }[]
-                  } | null
-                }
-              }
-            }[]
-          }
-        }
-      }[]
-    }
-  }
-}
-
-interface MyPullRequestStatus {
-  readonly number: number
-  readonly sha: string
-  readonly labels: readonly string[]
-  readonly state?: string
-}
-
-async function fetchDefaultBranch(inputs: Inputs, owner: string, repo: string): Promise<string> {
-  const octokit = getOctokit(inputs.token)
-  const res: DefaultBranchResponse = await octokit.graphql(
-    `
-query($owner: String!, $repo: String!) {
-  repository(owner: $owner, name: $repo) {
-    defaultBranchRef {
-      name
-    }
-  }
-}`,
-    { owner, repo }
-  )
-  return res.repository.defaultBranchRef.name
-}
-
-async function fetchPullRequestStatuses(
-  inputs: Inputs,
-  owner: string,
-  repo: string,
-  defaultBranch: string
-): Promise<MyPullRequestStatus[]> {
-  const octokit = getOctokit(inputs.token)
-  const baseBranches = inputs.baseBranches(defaultBranch)
-  let after: string | null = null
-  let hasNextPage = true
-  let statuses: MyPullRequestStatus[] = []
-
-  while (hasNextPage) {
-    const res: StatusesResponse = await octokit.graphql(
-      `
-query($owner: String!, $repo: String!, $after: String) {
-  repository(owner: $owner, name: $repo) {
-    pullRequests(after: $after, first: 100, states: OPEN, orderBy: { field: CREATED_AT, direction: DESC}) {
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-      edges {
-        node {
-          number
-          title
-          baseRef {
-            name
-          }
-          labels(first: 100) {
-            edges {
-              node {
-                name
-              }
-            }
-          }
-          commits(last: 1) {
-            edges {
-              node {
-                commit {
-                  oid
-                  message
-                  status {
-                    contexts {
-                      context
-                      state
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}`,
-      { owner, repo, after }
-    )
-    hasNextPage = res.repository.pullRequests.pageInfo.hasNextPage
-    after = res.repository.pullRequests.pageInfo.endCursor
-
-    const data = res.repository.pullRequests.edges
-      .filter((pr) => baseBranches.some((b) => b.test(pr.node.baseRef.name)))
-      .flatMap((pr) =>
-        pr.node.commits.edges.map((c) => ({
-          number: pr.node.number,
-          sha: c.node.commit.oid,
-          labels: pr.node.labels.edges.map((l) => l.node.name),
-          state: c.node.commit.status?.contexts.find((s) => s.context === inputs.commitStatusContext)?.state,
-        }))
-      )
-    statuses = [...statuses, ...data]
-  }
-
-  return statuses
 }


### PR DESCRIPTION
This patch uses the new APIs introduced on
https://github.com/yykamei/block-merge-based-on-time/pull/118

The old GitHub API calls will be removed from this patch.