### PR TITLE
Fix the test for inputs.prohibitedDates.length

### DIFF
--- a/__tests__/inputs.ts
+++ b/__tests__/inputs.ts
@@ -280,7 +280,7 @@ describe("Inputs", () => {
     })
     expect(inputs).toHaveProperty("timezone", IANAZone.create("Europe/Madrid"))
     expect(inputs).toHaveProperty("prohibitedDays", [])
-    expect(inputs.prohibitedDates.length).toEqual(286)
+    expect(inputs.prohibitedDates.length).toBeGreaterThan(250)
     expect(inputs.prohibitedDates).toContainEqual(
       Interval.fromDateTimes(
         DateTime.fromObject({
@@ -360,7 +360,7 @@ describe("Inputs", () => {
     })
     expect(inputs).toHaveProperty("timezone", IANAZone.create("Europe/Madrid"))
     expect(inputs).toHaveProperty("prohibitedDays", [])
-    expect(inputs.prohibitedDates.length).toEqual(286)
+    expect(inputs.prohibitedDates.length).toBeGreaterThan(250)
     expect(inputs.prohibitedDates).toContainEqual(
       Interval.fromDateTimes(
         DateTime.fromObject({


### PR DESCRIPTION
The test for `inputs.prohibitedDates.length` is flaky because it depends
on the actual holidays of the specific region. Still, I want to check
whether the `prohibitedDates` are added by regional holidays, so I
change the matcher from `toEqual` to `toBeGreaterThan`. It's sufficient
to check the enough amount of prohibited days are added.