### PR TITLE
Handle Validation error of the limit of commit statuses

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -1,15 +1,6 @@
 import { GitHub } from "@actions/github/lib/utils"
 import { Inputs } from "./inputs"
-
-export interface PullRequestStatus {
-  readonly owner: string
-  readonly repo: string
-  readonly number: number
-  readonly baseBranch: string
-  readonly sha: string
-  readonly labels: string[]
-  readonly state?: string
-}
+import type { PullRequestStatus } from "./types"
 
 interface Pull {
   readonly number: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,3 +26,18 @@ export interface HolidayEntry {
   readonly region: string
   readonly date: string
 }
+
+export interface PullRequestStatus {
+  readonly owner: string
+  readonly repo: string
+  readonly number: number
+  readonly baseBranch: string
+  readonly sha: string
+  readonly labels: string[]
+  readonly state?: string
+}
+
+export interface ErrorPullRequest {
+  readonly pull: PullRequestStatus
+  readonly error: Error
+}


### PR DESCRIPTION
Fix #199 

GitHub returns 422 error with the message "This SHA and context has
reached the maximum number of statuses." Such a error usually occurs
when old pull requests remain opened. Ideally, such errors should be
completely addressed, but we can't circumvent the limitation.

So far, the only thing we can is to skip such pull requests and handle
others correctly. Thus, I changed the `handleAllPulls` like these:

* Store an error when a pull request fails to get updated
* Continue processing on other pull requests
* Eventually, throw an error to say "Some of pull requests failed to get
  updated"