### PR TITLE
Put await explicitly for createCommitStatus()

### DIFF
--- a/__tests__/run.ts
+++ b/__tests__/run.ts
@@ -187,7 +187,9 @@ describe("run", () => {
 The failed pull requests are:
 
 - #4
-- #6`)
+- #6
+
+You can resolve the problems with these actions: updating the pull requests with new commits, or closing them.`)
       }
     })
   })

--- a/dist/index.js
+++ b/dist/index.js
@@ -13918,11 +13918,9 @@ function handlePull(inputs) {
 ;// CONCATENATED MODULE: ./src/main.ts
 
 
-
 process.on("unhandledRejection", handleError);
 run().catch(handleError);
 function handleError(err) {
-    core.error(`Unhandled error: ${err}`);
     (0,core.setFailed)(`Unhandled error: ${err}`);
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -13890,7 +13890,9 @@ function handleAllPulls(inputs) {
             throw new Error(`Some pull requests failed to get updated with the commit status context "${inputs.commitStatusContext}".
 The failed pull requests are:
 
-${errors.map((e) => `- #${e.pull.number}`).join("\n")}`);
+${errors.map((e) => `- #${e.pull.number}`).join("\n")}
+
+You can resolve the problems with these actions: updating the pull requests with new commits, or closing them.`);
         }
     });
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -13657,7 +13657,7 @@ function createCommitStatus(octokit, pullRequestStatus, inputs, state) {
     var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         const currentState = (_a = pullRequestStatus.state) === null || _a === void 0 ? void 0 : _a.toLowerCase();
-        core.debug(`Start createCommitStatus(), updating the state from ${currentState} to ${state}`);
+        core.debug(`Start createCommitStatus(), updating the state of "${pullRequestStatus.sha}" from "${currentState}" to "${state}"`);
         if (currentState === state) {
             return;
         }
@@ -13675,7 +13675,7 @@ function createCommitStatus(octokit, pullRequestStatus, inputs, state) {
                 break;
             }
         }
-        octokit.rest.repos.createCommitStatus({
+        yield octokit.rest.repos.createCommitStatus({
             owner,
             repo,
             sha,
@@ -13877,7 +13877,7 @@ function handleAllPulls(inputs) {
                 !pull.labels.includes(inputs.noBlockLabel)
                 ? "pending"
                 : "success";
-            core.debug(`We decided to make the state "${state}"`);
+            core.debug(`We decided to make the state "${state}" for "#${pull.number}"`);
             try {
                 yield createCommitStatus(octokit, pull, inputs, state);
             }

--- a/src/github.ts
+++ b/src/github.ts
@@ -72,7 +72,9 @@ export async function createCommitStatus(
   state: "success" | "pending"
 ): Promise<void> {
   const currentState = pullRequestStatus.state?.toLowerCase()
-  core.debug(`Start createCommitStatus(), updating the state of "${pullRequestStatus.sha}" from "${currentState}" to "${state}"`)
+  core.debug(
+    `Start createCommitStatus(), updating the state of "${pullRequestStatus.sha}" from "${currentState}" to "${state}"`
+  )
 
   if (currentState === state) {
     return

--- a/src/github.ts
+++ b/src/github.ts
@@ -72,7 +72,7 @@ export async function createCommitStatus(
   state: "success" | "pending"
 ): Promise<void> {
   const currentState = pullRequestStatus.state?.toLowerCase()
-  core.debug(`Start createCommitStatus(), updating the state from ${currentState} to ${state}`)
+  core.debug(`Start createCommitStatus(), updating the state of "${pullRequestStatus.sha}" from "${currentState}" to "${state}"`)
 
   if (currentState === state) {
     return
@@ -91,7 +91,7 @@ export async function createCommitStatus(
       break
     }
   }
-  octokit.rest.repos.createCommitStatus({
+  await octokit.rest.repos.createCommitStatus({
     owner,
     repo,
     sha,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,3 @@
-import * as core from "@actions/core"
 import { setFailed } from "@actions/core"
 import { run } from "./run"
 
@@ -6,6 +5,5 @@ process.on("unhandledRejection", handleError)
 run().catch(handleError)
 
 function handleError(err: unknown): void {
-  core.error(`Unhandled error: ${err}`)
   setFailed(`Unhandled error: ${err}`)
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -36,7 +36,7 @@ async function handleAllPulls(inputs: Inputs): Promise<void> {
       !pull.labels.includes(inputs.noBlockLabel)
         ? "pending"
         : "success"
-    core.debug(`We decided to make the state "${state}"`)
+    core.debug(`We decided to make the state "${state}" for "#${pull.number}"`)
     try {
       await createCommitStatus(octokit, pull, inputs, state)
     } catch (error) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -52,7 +52,9 @@ async function handleAllPulls(inputs: Inputs): Promise<void> {
       `Some pull requests failed to get updated with the commit status context "${inputs.commitStatusContext}".
 The failed pull requests are:
 
-${errors.map((e) => `- #${e.pull.number}`).join("\n")}`
+${errors.map((e) => `- #${e.pull.number}`).join("\n")}
+
+You can resolve the problems with these actions: updating the pull requests with new commits, or closing them.`
     )
   }
 }


### PR DESCRIPTION
The built JavaScript file seems to lack await/async functionality, so I put `await` for `octokit.rest.repos.createCommitStatus()` explicitly.

https://github.com/yykamei/playground/runs/3351012285?check_suite_focus=true