### PR TITLE
Use check-latest to ensure using the up-to-date version

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "12"
+          check-latest: true
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+          check-latest: true
           cache: npm
       - run: npm ci
       - run: npm run fmt:check

--- a/.github/workflows/fetch-holidays.yml
+++ b/.github/workflows/fetch-holidays.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "12"
+          check-latest: true
           cache: npm
       - run: npm ci
       - run: npm run fetch-holidays

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
+          check-latest: true
           cache: npm
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Close #215 

This codebase supports the latest versions of all LTS Node.js. So, I want to make sure the workflows run on the latest versions of Node.js for each LTS.