### PR TITLE
Use node16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["12", "14", "16"]
+        node: ["16"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/action.yml
+++ b/action.yml
@@ -48,5 +48,5 @@ branding:
   icon: stop-circle
   color: yellow
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
From [v2.285.0](https://github.com/actions/runner/releases/tag/v2.285.0), [actions/runner](https://github.com/actions/runner) supports Node.js 16. So, I want to move on to use `node16`.
