### PR TITLE
Fix __test__/inputs.ts

### DIFF
--- a/__tests__/inputs.ts
+++ b/__tests__/inputs.ts
@@ -453,7 +453,7 @@ describe("Inputs", () => {
     })
     expect(inputs).toHaveProperty("timezone", IANAZone.create("Europe/Madrid"))
     expect(inputs).toHaveProperty("prohibitedDays", [])
-    expect(inputs.prohibitedDates.length).toBeGreaterThan(250)
+    expect(inputs.prohibitedDates.length).toBeGreaterThan(240)
     expect(inputs.prohibitedDates).toContainEqual(
       Interval.fromDateTimes(
         DateTime.fromObject(

--- a/__tests__/inputs.ts
+++ b/__tests__/inputs.ts
@@ -349,7 +349,7 @@ describe("Inputs", () => {
     })
     expect(inputs).toHaveProperty("timezone", IANAZone.create("Europe/Madrid"))
     expect(inputs).toHaveProperty("prohibitedDays", [])
-    expect(inputs.prohibitedDates.length).toBeGreaterThan(250)
+    expect(inputs.prohibitedDates.length).toBeGreaterThan(240)
     expect(inputs.prohibitedDates).toContainEqual(
       Interval.fromDateTimes(
         DateTime.fromObject(


### PR DESCRIPTION
The test case `"returns a valid instance with base branches"` expects the `prohibitedDates` has the twice number of prohibited days because `H: ` and `BH:` parameters. However, Spain's number of holiday has been changed, so the test has failed.

We don't have to check the exact number of prohibited holidays, so the patch set an enoufh days to the expected value.