### PR TITLE
Warn with unsupported events, instead of throwing

### DIFF
--- a/__tests__/run.ts
+++ b/__tests__/run.ts
@@ -258,7 +258,7 @@ You can resolve the problems with these actions: updating the pull requests with
     })
 
     test("does not throw an error", async () => {
-      const warning = jest.spyOn(core, "warning").mockImplementation((jest.fn))
+      const warning = jest.spyOn(core, "warning").mockImplementation(jest.fn)
       await run()
 
       expect(warning).toBeCalledWith(`This action does not support the event "${event}"`)

--- a/__tests__/run.ts
+++ b/__tests__/run.ts
@@ -257,12 +257,11 @@ You can resolve the problems with these actions: updating the pull requests with
       Object.defineProperty(github.context, "eventName", { value: event })
     })
 
-    test("throws an error", async () => {
-      try {
-        await run()
-      } catch (e: any) {
-        expect(e.message).toEqual(`This action does not support the event "${event}"`)
-      }
+    test("does not throw an error", async () => {
+      const warning = jest.spyOn(core, "warning").mockImplementation((jest.fn))
+      await run()
+
+      expect(warning).toBeCalledWith(`This action does not support the event "${event}"`)
     })
   })
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -38006,7 +38006,7 @@ function run() {
             case "pull_request":
                 return handlePull(inputs);
             default:
-                throw new Error(`This action does not support the event "${github.context.eventName}"`);
+                core.warning(`This action does not support the event "${github.context.eventName}"`);
         }
     });
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -16,7 +16,7 @@ export async function run(): Promise<void> {
     case "pull_request":
       return handlePull(inputs)
     default:
-      throw new Error(`This action does not support the event "${context.eventName}"`)
+      core.warning(`This action does not support the event "${context.eventName}"`)
   }
 }
 


### PR DESCRIPTION
Close #1362

Sometimes, developers wants to use this GitHub Action in conjunction with other jobs in one GitHub Workflow, and they might declare GitHub events that are not supported by yykamei/block-merge-based-on-time.

Previously, this Action throwed an error when an unsupported event triggers it, but I want to change the behavior not to raise an error. Instead, I made changes to show warnings for developer experiences.