### PR TITLE
Add a new output, pr-blocked

### DIFF
--- a/.github/workflows/block-merge-based-on-time.yaml
+++ b/.github/workflows/block-merge-based-on-time.yaml
@@ -9,11 +9,11 @@ jobs:
   block:
     runs-on: ubuntu-latest
     steps:
-      - uses: yykamei/block-merge-based-on-time@outputs
+      - uses: yykamei/block-merge-based-on-time@main
         id: block
         with:
           timezone: Asia/Tokyo
-          after: 22:00
+          after: 03:00
           before: 04:00
       - run: echo pr-blocked=${{ steps.block.outputs.pr-blocked }}
         if: github.event_name == 'pull_request'

--- a/.github/workflows/block-merge-based-on-time.yaml
+++ b/.github/workflows/block-merge-based-on-time.yaml
@@ -9,7 +9,7 @@ jobs:
   block:
     runs-on: ubuntu-latest
     steps:
-      - uses: yykamei/block-merge-based-on-time@main
+      - uses: yykamei/block-merge-based-on-time@outputs
         id: block
         with:
           timezone: Asia/Tokyo

--- a/.github/workflows/block-merge-based-on-time.yaml
+++ b/.github/workflows/block-merge-based-on-time.yaml
@@ -13,7 +13,7 @@ jobs:
         id: block
         with:
           timezone: Asia/Tokyo
-          after: 03:00
+          after: 22:00
           before: 04:00
       - run: echo pr-blocked=${{ steps.block.outputs.pr-blocked }}
         if: github.event_name == 'pull_request'

--- a/.github/workflows/block-merge-based-on-time.yaml
+++ b/.github/workflows/block-merge-based-on-time.yaml
@@ -1,6 +1,7 @@
 name: Block Merge Based on Time
 on:
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: "*/30 * * * *"
 

--- a/.github/workflows/block-merge-based-on-time.yaml
+++ b/.github/workflows/block-merge-based-on-time.yaml
@@ -1,0 +1,18 @@
+name: Block Merge Based on Time
+on:
+  pull_request:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  block:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: yykamei/block-merge-based-on-time@main
+        id: block
+        with:
+          timezone: Asia/Tokyo
+          after: 03:00
+          before: 04:00
+      - run: echo pr-blocked=${{ steps.block.outputs.pr-blocked }}
+        if: github.event_name == 'pull_request'

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ jobs:
           before: 09:00
           base-branches: "(default)"
           prohibited-days-dates: "Sunday, 2021-10-01, 2021-12-29/2022-01-04, H:United States, BH:United States"
+      - run: echo pr-blocked=${{ steps.block.outputs.pr-blocked }}
+        if: github.event_name == 'pull_request'
 ```
 
 ### Action inputs
@@ -55,6 +57,10 @@ These are all available inputs.
 | `commit-status-description-while-blocking` | The commit status description shown while blocking                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | `false`  | `The PR can't be merged based on time, which is due to your organization's policy` |
 | `commit-status-url`                        | The commit status URL to describe why this action is conducted                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | `false`  | `""`                                                                               |
 | `token`                                    | The GitHub token used to create an authenticated client                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `false`  | `GITHUB_TOKEN`                                                                     |
+
+### Action outputs
+
+- `pr-blocked` — A boolean value to indicate the pull reuqest is blocked. This is set only when the `pull_request` event occurs.
 
 ## Regional holidays
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: yykamei/block-merge-based-on-time@main
+        id: block
         with:
           timezone: Pacific/Honolulu
           after: "17:30, 16:30 on Monday"

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,9 @@ inputs:
     description: The GitHub token used to create an authenticated client
     required: false
     default: ${{ github.token }}
+outputs:
+  pr-blocked:
+    description: "A boolean value to indicate the pull reuqest is blocked. This is set only when the `pull_request` event occurs."
 branding:
   icon: stop-circle
   color: yellow

--- a/dist/index.js
+++ b/dist/index.js
@@ -39506,6 +39506,7 @@ function handlePull(inputs) {
             ? "pending"
             : "success";
         core.debug(`We decided to make the state "${state}"`);
+        core.setOutput("pr-blocked", state === "success" ? "false" : "true");
         return createCommitStatus(octokit, result.pull, inputs, state);
     });
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -76,5 +76,6 @@ async function handlePull(inputs: Inputs): Promise<void> {
       ? "pending"
       : "success"
   core.debug(`We decided to make the state "${state}"`)
+  core.setOutput("pr-blocked", state === "success" ? "false" : "true")
   return createCommitStatus(octokit, result.pull, inputs, state)
 }


### PR DESCRIPTION
Close #1341

If you want to do something based on the result of this action, `pr-blocked` might be useful.

This new output will indicate the pull request is blocked or not through an output parameter.

You can use it in your workflow like this:

```yaml
on:
  pull_request:
  schedule:
    - cron: "*/30 * * * *"
jobs:
  block:
    runs-on: ubuntu-latest
    steps:
      - uses: yykamei/block-merge-based-on-time@main
        id: block
        with:
          timezone: Asia/Tokyo
          after: 18:00
          before: 09:00
      - run: echo pr-blocked=${{ steps.block.outputs.pr-blocked }}
        if: github.event_name == 'pull_request'
```

Note `pr-blocked` won't be set on other than the `pull_request` event.