### PR TITLE
Add permissions to the example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ on:
 jobs:
   block:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      statuses: write
     steps:
       - uses: yykamei/block-merge-based-on-time@main
         id: block


### PR DESCRIPTION
This might be related to #1736.

I want to update the example on README to add `permissions` to give the least required permissions to `GITHUB_TOKEN`. As #1736 describes the problem, I also found the issue with the error message "Resource not accessible by integration." According to [the changelog](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/) in the past, `statuses` has `write` permission by default as long as the repository is configured with the default permissive policy, but some organizations/repositories may have strict rules, so I think it's worth mentioning the `permissions`.