### PR TITLE
Add pull_request_target trigger on ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,12 @@ on:
   push:
     branches: [main]
   pull_request:
+  pull_request_target:
+    types: [labeled]
   workflow_dispatch:
 jobs:
   ci:
+    if: github.event_name != 'pull_request_target'
     continue-on-error: true
     runs-on: ubuntu-latest
     strategy:
@@ -28,7 +31,7 @@ jobs:
     steps:
       - uses: actions/dependency-review-action@v4
   auto-build:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v1


### PR DESCRIPTION
Previously, a GitHub run triggered by forked pull requests cannot access to secrets on this repository. I want to make sure auto-build is also triggered by forked pull requests.

According the article below, `pull_request_target` with an explicit checkout of an untrusted PR is dangerous, so I followed the advice and made the workflow trigger only on labeled.

https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/