### PR TITLE
Use Node.js v22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["20"]
+        node: ["20", "22"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/fetch-holidays.yml
+++ b/.github/workflows/fetch-holidays.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           check-latest: true
           cache: npm
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           check-latest: true
           cache: npm
 


### PR DESCRIPTION
Node.js v22 is [available](https://nodejs.org/en/blog/announcements/v22-release-announce), and now it's [entered](https://nodejs.org/en/blog/release/v22.11.0) Long Term Support (LTS).

I think it's time to use it in this repository CI.