### PR TITLE
fix: Modified so that holidays, etc. are not taken.

### DIFF
--- a/src/fetch-holidays.ts
+++ b/src/fetch-holidays.ts
@@ -104,7 +104,7 @@ const calendars = {
   Ireland: "en.irish#holiday@group.v.calendar.google.com",
   Iceland: "en.is#holiday@group.v.calendar.google.com",
   Italy: "en.italian#holiday@group.v.calendar.google.com",
-  Japan: "en.japanese#holiday@group.v.calendar.google.com",
+  Japan: "en.japanese.official#holiday@group.v.calendar.google.com",
   Jersey: "en.je#holiday@group.v.calendar.google.com",
   Israel: "en.jewish#holiday@group.v.calendar.google.com",
   Jamaica: "en.jm#holiday@group.v.calendar.google.com",


### PR DESCRIPTION
## Overview.
Hello, I always appreciate the `block-merge-based-on-time`.
When I set up a Japanese holiday, even holidays such as Shichi-Go-San are block-merged and I can't merge them.
We do not expect that there is much demand to block-merge on national holidays, so please confirm that this has been fixed.

We are sorry, but we do not have the environment to test this modification at hand and have not been able to verify the operation, so we would appreciate it if you could confirm this as well.

## Reference article list
https://zenn.dev/gomo/articles/2ff8501f7afaff
https://support.google.com/calendar/answer/13748345?hl=ja&co=GENIE.Platform%3DDesktop

---
# supplement
Due to the above machine translation, the original Japanese is given below.


## 概要
こんにちは、いつも`block-merge-based-on-time`をありがたく利用させていただいております。
日本の祝日を設定した時に、七五三などの祭日でもblock-mergeとなりmergeができない状況となっておりました。
恐らく祭日にblock-mergeしたい需要はあまり無いと予想しており、こちらの修正をご確認お願いできますでしょうか。

申し訳ありませんが、手元でこの修正を試す環境がなく動作の検証が出来ておらず、その点も含めてご確認いただけますと幸いです。

## 参考記事一覧

https://zenn.dev/gomo/articles/2ff8501f7afaff
https://support.google.com/calendar/answer/13748345?hl=ja&co=GENIE.Platform%3DDesktop


