### PR TITLE
fix: support auto-build for forked pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/dependency-review-action@v4
-  auto-build:
-    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+  auto-build-trusted:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v2
@@ -57,3 +57,20 @@ jobs:
         if: steps.git_diff.outcome == 'failure'
         with:
           commit-message: "Run `npm run build`"
+  auto-build-untrusted:
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          check-latest: true
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: git diff --exit-code --quiet
+        id: git_diff
+        continue-on-error: true


### PR DESCRIPTION
This PR splits the auto-build job into trusted and untrusted jobs, allowing forked PRs to run the build without requiring secrets or privileged tokens. Trusted PRs (from the base repo) can still push build results if needed. Fixes workflow failures for forked PRs.