### PR TITLE
Show stacktrace in handleError()

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -40557,7 +40557,12 @@ async function handlePull(inputs) {
 process.on("unhandledRejection", handleError);
 run().catch(handleError);
 function handleError(err) {
-    (0,core.setFailed)(`Unhandled error: ${err}`);
+    if (err instanceof Error) {
+        (0,core.setFailed)(`Unhandled error: ${err.message}\n${err.stack}`);
+    }
+    else {
+        (0,core.setFailed)(`Unhandled error: ${err}`);
+    }
 }
 
 })();

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,5 +5,9 @@ process.on("unhandledRejection", handleError)
 run().catch(handleError)
 
 function handleError(err: unknown): void {
-  setFailed(`Unhandled error: ${err}`)
+  if (err instanceof Error) {
+    setFailed(`Unhandled error: ${err.message}\n${err.stack}`)
+  } else {
+    setFailed(`Unhandled error: ${err}`)
+  }
 }


### PR DESCRIPTION
Currently, debugging this action is difficult because `handleError()` just shows an error message without stacktrace. I want to show stacktrace if `err` is an instance of `Error`.