### PR TITLE
Use GitHub App token to run BMBT on forked PR

### DIFF
--- a/.github/workflows/block-merge-based-on-time.yaml
+++ b/.github/workflows/block-merge-based-on-time.yaml
@@ -13,11 +13,17 @@ jobs:
       pull-requests: read
       statuses: write
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
       - uses: yykamei/block-merge-based-on-time@main
         id: block
         with:
           timezone: Asia/Tokyo
           after: 03:00
           before: 04:00
+          token: ${{ steps.app-token.outputs.token }}
       - run: echo pr-blocked=${{ steps.block.outputs.pr-blocked }}
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Related to #1808

Currently, the workflow "Block Merge Based on Time" does not work if a pull request is opened from a fork repository. This is because the `GITHUB_TOKEN` doesn't have `write` permission to `statuses` (See [this page](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) for more details).

I want to update README to instruct how to allow the workflow to run on pull requests from forked repositories.

