### PR TITLE
Revert "Use GitHub App token to run BMBT on forked PR"

### DIFF
--- a/.github/workflows/block-merge-based-on-time.yaml
+++ b/.github/workflows/block-merge-based-on-time.yaml
@@ -13,17 +13,11 @@ jobs:
       pull-requests: read
       statuses: write
     steps:
-      - uses: actions/create-github-app-token@v2
-        id: app-token
-        with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
       - uses: yykamei/block-merge-based-on-time@main
         id: block
         with:
           timezone: Asia/Tokyo
           after: 03:00
           before: 04:00
-          token: ${{ steps.app-token.outputs.token }}
       - run: echo pr-blocked=${{ steps.block.outputs.pr-blocked }}
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Reverts yykamei/block-merge-based-on-time#2339

I forgot that "secrets are not passed to the runner when a workflow is triggered from a forked repository".