### PR TITLE
refactor!: remove unused fields from HolidayEntry interface

### DIFF
--- a/src/fetch-holidays.ts
+++ b/src/fetch-holidays.ts
@@ -284,11 +284,8 @@ const fetch = (region: string, calendarId: string): Promise<HolidayEntry[]> => {
           const parsedData: any = JSON.parse(data) // eslint-disable-line @typescript-eslint/no-explicit-any
           resolve(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            parsedData.items.map(({ id, status, summary, start }: any) => {
+            parsedData.items.map(({ start }: any) => {
               return {
-                id,
-                status,
-                summary,
                 region,
                 date: start.date,
               }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,9 +20,6 @@ export interface Holidays {
 }
 
 export interface HolidayEntry {
-  readonly id: string
-  readonly status: string
-  readonly summary: string
   readonly region: string
   readonly date: string
 }


### PR DESCRIPTION
Remove `id`, `status`, and `summary` fields from HolidayEntry interface as they are not used in the application logic. This simplifies the data structure and makes it easier to maintain `holidays.json` and create custom holiday definitions.