### PR TITLE
Specify node24 in `using`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,11 @@ jobs:
     if: github.event_name != 'pull_request_target'
     continue-on-error: true
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: ["20", "22"]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 24
           check-latest: true
           cache: npm
       - run: npm ci
@@ -45,7 +42,7 @@ jobs:
           ref: ${{ github.head_ref }}
       - uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: 24
           check-latest: true
           cache: npm
       - run: npm ci
@@ -66,7 +63,7 @@ jobs:
           ref: ${{ github.head_ref }}
       - uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: 24
           check-latest: true
           cache: npm
       - run: npm ci

--- a/.github/workflows/fetch-holidays.yml
+++ b/.github/workflows/fetch-holidays.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
       - uses: actions/setup-node@v5
         with:
-          node-version: "22"
+          node-version: 24
           check-latest: true
           cache: npm
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: "22"
+          node-version: 24
           check-latest: true
           cache: npm
 

--- a/action.yml
+++ b/action.yml
@@ -58,5 +58,5 @@ branding:
   icon: stop-circle
   color: yellow
 runs:
-  using: node20
+  using: node24
   main: dist/index.js


### PR DESCRIPTION
According to the release of GitHub Actions Runner, Node24 is available on GitHub-hosted runners.

https://github.com/actions/runner/releases/tag/v2.327.0

Like https://github.com/actions/checkout/releases/tag/v5.0.0, I want to use Node24 for this Action.