### PR TITLE
fix: Use client ID for app token workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/fetch-holidays.yml
+++ b/.github/workflows/fetch-holidays.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

Update the GitHub App token creation steps in CI, release, and holiday-fetch workflows to use the recommended `client-id` input.

## Purpose

Remove the deprecation warning emitted by `actions/create-github-app-token@v3` for the legacy `app-id` input.

## Background

`actions/create-github-app-token@v3` now recommends the GitHub App Client ID via `client-id`. The repository variable `APP_CLIENT_ID` is already configured, so the workflows can move away from the deprecated numeric App ID input.

## Changes

Replace `app-id: ${{ vars.APP_ID }}` with `client-id: ${{ vars.APP_CLIENT_ID }}` in:

- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`
- `.github/workflows/fetch-holidays.yml`

The existing private key secret remains unchanged.

## Out of Scope

No action version bumps or private key changes are included.

## Related

- https://github.com/yykamei/block-merge-based-on-time/actions/runs/26682801223

## Testing

- Verified no `app-id` references remain in `.github/workflows`.
- Verified all three workflow files now reference `client-id: ${{ vars.APP_CLIENT_ID }}`.

## Post-Release Verification

Confirm the next affected workflow run no longer emits the `app-id` deprecation warning and that the app token step succeeds.

## Operational Notes

`vars.APP_CLIENT_ID` must remain set to the GitHub App Client ID. Labels, reviewers, and assignees are intentionally left unset.
